### PR TITLE
create the table in DynamoDbLocal automatically

### DIFF
--- a/agonyforge-mud-models-dynamodb/src/main/bash/01-create-dynamodb-table.sh
+++ b/agonyforge-mud-models-dynamodb/src/main/bash/01-create-dynamodb-table.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -x
+
+# create DynamoDB table in DynamoDbLocal
+# If you remove the $AWS_ENDPOINT argument, this ought to work for real in AWS too.
+# My personal preference would be to use the CloudFormation template instead, though.
+
+aws $AWS_ENDPOINT \
+    dynamodb create-table \
+        --no-paginate \
+        --table-name agonyforge \
+        --billing-mode PAY_PER_REQUEST \
+        --sse-specification "Enabled=true" \
+        --attribute-definitions \
+            AttributeName=pk,AttributeType=S \
+            AttributeName=sk,AttributeType=S \
+            AttributeName=gsi1pk,AttributeType=S \
+            AttributeName=gsi2pk,AttributeType=S \
+        --key-schema \
+            AttributeName=pk,KeyType=HASH \
+            AttributeName=sk,KeyType=RANGE \
+        --global-secondary-indexes \
+            "[
+                {
+                    \"IndexName\": \"gsi1\",
+                    \"KeySchema\": [{\"AttributeName\":\"gsi1pk\",\"KeyType\":\"HASH\"},{\"AttributeName\":\"pk\",\"KeyType\":\"RANGE\"}],
+                    \"Projection\": {
+                        \"ProjectionType\":\"ALL\"
+                    }
+                },
+                {
+                    \"IndexName\": \"gsi2\",
+                    \"KeySchema\": [{\"AttributeName\":\"gsi2pk\",\"KeyType\":\"HASH\"},{\"AttributeName\":\"pk\",\"KeyType\":\"RANGE\"}],
+                    \"Projection\": {
+                        \"ProjectionType\":\"ALL\"
+                    }
+                }
+            ]"
+
+# sets the TTL attribute in table
+aws $AWS_ENDPOINT \
+    dynamodb update-time-to-live \
+        --table-name agonyforge \
+        --time-to-live-specification "Enabled=true, AttributeName=ttl"

--- a/cloudformation/dynamodb.yaml
+++ b/cloudformation/dynamodb.yaml
@@ -8,14 +8,16 @@ Resources:
   DynamoMainTable:
     Type: AWS::DynamoDB::Table
     Properties:
+      TableName:
+        Ref: TableName
       AttributeDefinitions:
         - AttributeName: pk
           AttributeType: S
         - AttributeName: sk
           AttributeType: S
-        - AttributeName: gsipk1
+        - AttributeName: gsi1pk
           AttributeType: S
-        - AttributeName: gsipk2
+        - AttributeName: gsi2pk
           AttributeType: S
         - AttributeName: ttl
           AttributeType: N
@@ -24,10 +26,13 @@ Resources:
           KeyType: HASH
         - AttributeName: sk
           KeyType: RANGE
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
       GlobalSecondaryIndexes:
         - IndexName: gsi1
           KeySchema:
-            - AttributeName: gsipk1
+            - AttributeName: gsi1pk
               KeyType: HASH
             - AttributeName: pk
               KeyType: RANGE
@@ -35,15 +40,10 @@ Resources:
             ProjectionType: ALL
         - IndexName: gsi2
           KeySchema:
-            - AttributeName: gsipk2
+            - AttributeName: gsi2pk
               KeyType: HASH
             - AttributeName: pk
               KeyType: RANGE
       BillingMode: PAY_PER_REQUEST
       SSESpecification:
         SSEEnabled: 'True'
-      TableName:
-        Ref: TableName
-      TimeToLiveSpecification:
-        AttributeName: ttl
-        Enabled: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,26 @@ services:
       - "8000:8000"
     command: "-jar DynamoDBLocal.jar -sharedDb -inMemory"
 
+  # credit to https://aws.plainenglish.io/run-aws-dynamodb-locally-2788ad73c4db for this one
+  aws-cli:
+    image: amazon/aws-cli
+    depends_on:
+      - dynamodb
+    environment:
+      AWS_ACCESS_KEY_ID: x
+      AWS_SECRET_ACCESS_KEY: x
+      AWS_REGION: us-west-2
+      AWS_ENDPOINT: "--endpoint-url http://dynamodb:8000"
+    entrypoint: /bin/sh -c
+    volumes:
+      - './agonyforge-mud-models-dynamodb/src/main/bash:/init-scripts'
+    command: >
+      '
+      for script_name in /init-scripts/*.sh; do
+        sh $$script_name
+      done
+      '
+
   activemq:
     image: symptoma/activemq:5.17.1-envvars
     ports:


### PR DESCRIPTION
I got tired of having to manually create the table in DynamoDbLocal every time I restarted the MUD. Now there is a directory where you can place bash scripts that run right after Dynamo becomes available. The script runs aws-cli in another container.

You could run the same script without the `--endpoint` arguments to build the table in AWS if you wanted to, although I prefer to use CloudFormation myself.