### PR TITLE
Switch to RabbitMQ

### DIFF
--- a/agonyforge-mud-core/build.gradle
+++ b/agonyforge-mud-core/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.agonyforge'
-version = '0.0.9'
+version = '0.0.10-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/config/MqBrokerProperties.java
+++ b/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/config/MqBrokerProperties.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConfigurationProperties(prefix = "mud.broker")
-public class ActiveMqBrokerProperties {
+public class MqBrokerProperties {
     private Boolean ssl;
     private String host;
     private Integer port;

--- a/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/config/WebSocketBrokerConfiguration.java
+++ b/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/config/WebSocketBrokerConfiguration.java
@@ -20,10 +20,10 @@ import org.springframework.web.socket.server.support.HttpSessionHandshakeInterce
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketBrokerConfiguration extends AbstractSessionWebSocketMessageBrokerConfigurer<Session> {
-    private final ActiveMqBrokerProperties brokerProperties;
+    private final MqBrokerProperties brokerProperties;
 
     @Autowired
-    public WebSocketBrokerConfiguration(ActiveMqBrokerProperties brokerProperties) {
+    public WebSocketBrokerConfiguration(MqBrokerProperties brokerProperties) {
         this.brokerProperties = brokerProperties;
     }
 

--- a/agonyforge-mud-demo/build.gradle
+++ b/agonyforge-mud-demo/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.agonyforge'
-version = '0.0.9'
+version = '0.0.10-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/agonyforge-mud-models-dynamodb/build.gradle
+++ b/agonyforge-mud-models-dynamodb/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'com.agonyforge'
-version '0.0.9'
+version '0.0.10-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,18 +39,43 @@ services:
       done
       '
 
-  activemq:
-    image: symptoma/activemq:5.17.1-envvars
+# This is the highest version of RabbitMQ that is supported by AWS's "Amazon MQ"
+# product as of writing this. Any message broker capable of supporting the STOMP
+# protocol should be able to work. I am targeting Agony Forge at being deployed
+# in AWS, so I'm trying to keep things like this as close as possible to what you'd
+# see there.
+  rabbitmq:
+    image: rabbitmq:3.10-management
     ports:
+      - "127.0.0.1:5672:5672"
+      - "127.0.0.1:15672:15672"
       - "127.0.0.1:61613:61613"
-      - "127.0.0.1:8161:8161"
-    environment:
-      ACTIVEMQ_WEBCONSOLE_USE_DEFAULT_ADDRESS: "false"
+    volumes:
+      - './src/main/resources/rabbitmq/enabled_plugins:/etc/rabbitmq/enabled_plugins'
 
-      # user with access to web UI
-      ACTIVEMQ_WEBADMIN_USERNAME: admin
-      ACTIVEMQ_WEBADMIN_PASSWORD: admin
-
-      # user with access to broker
-      ACTIVEMQ_USERNAME: mud
-      ACTIVEMQ_PASSWORD: mud
+# If you'd rather use ActiveMQ here's a sample configuration for it.
+# This is the highest version supported by AWS's "Amazon MQ" version of ActiveMQ as
+# of writing this.
+#
+# I stopped using it and switched to RabbitMQ because this version is getting pretty
+# old. Apache released an update to ActiveMQ called Artemis and Spring Boot's starter
+# library for activemq stopped getting updated in favor of their artemis one. Since I
+# can't use newer versions on AWS and I can't use the old Spring Boot library in the
+# latest Spring Boot, it made sense to swap over to RabbitMQ which seems to be getting
+# more current support over there.
+#
+#  activemq:
+#    image: symptoma/activemq:5.17.1-envvars
+#    ports:
+#      - "127.0.0.1:61613:61613"
+#      - "127.0.0.1:8161:8161"
+#    environment:
+#      ACTIVEMQ_WEBCONSOLE_USE_DEFAULT_ADDRESS: "false"
+#
+#      # user with access to web UI
+#      ACTIVEMQ_WEBADMIN_USERNAME: admin
+#      ACTIVEMQ_WEBADMIN_PASSWORD: admin
+#
+#      # user with access to broker
+#      ACTIVEMQ_USERNAME: mud
+#      ACTIVEMQ_PASSWORD: mud

--- a/mud.EXAMPLE.env
+++ b/mud.EXAMPLE.env
@@ -10,15 +10,15 @@ MUD_DYNAMO_TABLE_NAME=agonyforge
 MUD_DYNAMO_GSI1_NAME=gsi1
 MUD_DYNAMO_GSI2_NAME=gsi2
 
-# The following tell the MUD where to find ActiveMQ's STOMP connector, and the credentials to use to
+# The following tell the MUD where to find the broker's STOMP connector, and the credentials to use to
 # log into it both as the "System" user and a regular user.
 MUD_BROKER_SSL=false
-MUD_BROKER_HOST=activemq
+MUD_BROKER_HOST=rabbitmq
 MUD_BROKER_PORT=61613
-MUD_BROKER_SYSTEM_USERNAME=admin
-MUD_BROKER_SYSTEM_PASSWORD=admin
-MUD_BROKER_CLIENT_USERNAME=mud
-MUD_BROKER_CLIENT_PASSWORD=mud
+MUD_BROKER_SYSTEM_USERNAME=guest
+MUD_BROKER_SYSTEM_PASSWORD=guest
+MUD_BROKER_CLIENT_USERNAME=guest
+MUD_BROKER_CLIENT_PASSWORD=guest
 
 # You will need to go to https://developer.amazon.com and set up a security profile there. It will give you
 # a client ID and secret that you can use to create an OAuth client in AWS Cognito. Then you will be able to

--- a/src/main/resources/rabbitmq/enabled_plugins
+++ b/src/main/resources/rabbitmq/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_management,rabbitmq_stomp].


### PR DESCRIPTION
Agony Forge is designed to be deployed into AWS using DynamoDB and "Amazon MQ" but I've run into a problem with that. AWS's support for ActiveMQ has fallen behind, and Apache has released a new version called Artemis. AWS doesn't support Artemis, but Spring Boot 3 no longer supports versions prior to Artemis. The starter package `-activemq` has no updates for Spring Boot 3 and there's a new `-artemis` starter instead.

So I'm stuck: I can't upgrade to Artemis because AWS doesn't have it, and I can't keep using ActiveMQ because Spring Boot 3 doesn't support it. The answer seems to be switching to RabbitMQ where AWS has a fairly recent version and the Spring Boot 3 support is there. It has a STOMP connector and it seems to be functionally equivalent so far.

If you would rather use ActiveMQ I have left the configuration in `docker-compose.yaml` for it with an explanation. It still works fine for me in Docker. Any other message broker that supports STOMP should work just fine too. The thing that _really_ ties Agony Forge to AWS is DynamoDB.