### PR TITLE
added very simple in-game passage of time

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/RepositoryBundle.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/RepositoryBundle.java
@@ -2,23 +2,31 @@ package com.agonyforge.mud.demo.cli;
 
 import com.agonyforge.mud.models.dynamodb.repository.MudCharacterRepository;
 import com.agonyforge.mud.models.dynamodb.repository.MudItemRepository;
+import com.agonyforge.mud.models.dynamodb.repository.MudPropertyRepository;
 import com.agonyforge.mud.models.dynamodb.repository.MudRoomRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class RepositoryBundle {
+    private final MudPropertyRepository propertyRepository;
     private final MudCharacterRepository characterRepository;
     private final MudItemRepository itemRepository;
     private final MudRoomRepository roomRepository;
 
     @Autowired
-    public RepositoryBundle(MudCharacterRepository characterRepository,
+    public RepositoryBundle(MudPropertyRepository propertyRepository,
+                            MudCharacterRepository characterRepository,
                             MudItemRepository itemRepository,
                             MudRoomRepository roomRepository) {
+        this.propertyRepository = propertyRepository;
         this.characterRepository = characterRepository;
         this.itemRepository = itemRepository;
         this.roomRepository = roomRepository;
+    }
+
+    public MudPropertyRepository getPropertyRepository() {
+        return propertyRepository;
     }
 
     public MudCharacterRepository getCharacterRepository() {

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/TimeCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/TimeCommand.java
@@ -1,0 +1,54 @@
+package com.agonyforge.mud.demo.cli.command;
+
+import com.agonyforge.mud.core.cli.Question;
+import com.agonyforge.mud.core.web.model.Input;
+import com.agonyforge.mud.core.web.model.Output;
+import com.agonyforge.mud.core.web.model.WebSocketContext;
+import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.models.dynamodb.impl.MudProperty;
+import com.agonyforge.mud.models.dynamodb.service.CommService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static com.agonyforge.mud.demo.event.WeatherListener.PROPERTY_HOUR;
+
+@Component
+public class TimeCommand extends AbstractCommand {
+    @Autowired
+    public TimeCommand(RepositoryBundle repositoryBundle, CommService commService) {
+        super(repositoryBundle, commService);
+    }
+
+    @Override
+    public Question execute(Question question, WebSocketContext webSocketContext, List<String> tokens, Input input, Output output) {
+        MudProperty mudHour = getRepositoryBundle()
+            .getPropertyRepository()
+            .getByName(PROPERTY_HOUR)
+            .orElseThrow();
+
+        int hour = Integer.parseInt(mudHour.getValue());
+        String timeOfDay;
+
+        if (hour < 6) {
+            timeOfDay = "at night";
+        } else if (hour <= 12) {
+            timeOfDay = "in the morning";
+        } else if (hour < 18) {
+            timeOfDay = "in the afternoon";
+            hour -= 12;
+        } else {
+            timeOfDay = "in the evening";
+            hour -= 12;
+        }
+
+        switch (hour) {
+            case 0 -> output.append("[dblue]It is midnight.");
+            case 12 -> output.append("[yellow]It is noon.");
+            default -> output.append("[default]The hour is %d o'clock %s.", hour, timeOfDay);
+        }
+
+        return question;
+    }
+}

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
@@ -51,6 +51,8 @@ public class CommandLoader {
             refs.add(new CommandReference("10", "TELL", "tellCommand"));
             refs.add(new CommandReference("10", "WHISPER", "whisperCommand"));
 
+            refs.add(new CommandReference("15", "TIME", "timeCommand"));
+
             LOGGER.info("Creating command references");
             commandRepository.saveAll(refs);
         }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/WorldLoader.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/WorldLoader.java
@@ -3,9 +3,11 @@ package com.agonyforge.mud.demo.config;
 import com.agonyforge.mud.models.dynamodb.constant.Direction;
 import com.agonyforge.mud.models.dynamodb.constant.WearSlot;
 import com.agonyforge.mud.models.dynamodb.impl.MudItem;
+import com.agonyforge.mud.models.dynamodb.impl.MudProperty;
 import com.agonyforge.mud.models.dynamodb.impl.MudRoom;
 import com.agonyforge.mud.models.dynamodb.impl.MudZone;
 import com.agonyforge.mud.models.dynamodb.repository.MudItemRepository;
+import com.agonyforge.mud.models.dynamodb.repository.MudPropertyRepository;
 import com.agonyforge.mud.models.dynamodb.repository.MudRoomRepository;
 import com.agonyforge.mud.models.dynamodb.repository.MudZoneRepository;
 import org.slf4j.Logger;
@@ -17,18 +19,23 @@ import javax.annotation.PostConstruct;
 import java.util.List;
 import java.util.UUID;
 
+import static com.agonyforge.mud.demo.event.WeatherListener.PROPERTY_HOUR;
+
 @Component
 public class WorldLoader {
     private static final Logger LOGGER = LoggerFactory.getLogger(WorldLoader.class);
 
+    private final MudPropertyRepository propertyRepository;
     private final MudZoneRepository zoneRepository;
     private final MudRoomRepository roomRepository;
     private final MudItemRepository itemRepository;
 
     @Autowired
-    public WorldLoader(MudZoneRepository zoneRepository,
+    public WorldLoader(MudPropertyRepository propertyRepository,
+                       MudZoneRepository zoneRepository,
                        MudRoomRepository roomRepository,
                        MudItemRepository itemRepository) {
+        this.propertyRepository = propertyRepository;
         this.zoneRepository = zoneRepository;
         this.roomRepository = roomRepository;
         this.itemRepository = itemRepository;
@@ -36,6 +43,13 @@ public class WorldLoader {
 
     @PostConstruct
     public void loadWorld() {
+        if (propertyRepository.getByName(PROPERTY_HOUR).isEmpty()) {
+            MudProperty mudHour = new MudProperty(PROPERTY_HOUR, "0");
+
+            LOGGER.info("Setting world time");
+            propertyRepository.save(mudHour);
+        }
+
         if (zoneRepository.getById(1L).isEmpty()) {
             MudZone zone = new MudZone();
 

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/event/WeatherListener.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/event/WeatherListener.java
@@ -1,0 +1,64 @@
+package com.agonyforge.mud.demo.event;
+
+import com.agonyforge.mud.core.service.timer.TimerEvent;
+import com.agonyforge.mud.core.web.model.Output;
+import com.agonyforge.mud.models.dynamodb.impl.MudProperty;
+import com.agonyforge.mud.models.dynamodb.repository.MudPropertyRepository;
+import com.agonyforge.mud.models.dynamodb.service.CommService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class WeatherListener {
+    public static final String PROPERTY_HOUR = "mud.hour";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WeatherListener.class);
+
+    private final MudPropertyRepository mudPropertyRepository;
+    private final CommService commService;
+
+    @Autowired
+    public WeatherListener(MudPropertyRepository mudPropertyRepository, CommService commService) {
+        this.mudPropertyRepository = mudPropertyRepository;
+        this.commService = commService;
+    }
+
+    @EventListener
+    public void onTimerEvent(TimerEvent event) {
+        if (!TimeUnit.MINUTES.equals(event.getFrequency())) {
+            return;
+        }
+
+        final int newHour = advanceTime();
+
+        switch (newHour) {
+            case 0 -> commService.sendToAll(new Output("[dblue]It is midnight."));
+            case 6 -> commService.sendToAll(new Output("[dyellow]The sun is rising."));
+            case 12 -> commService.sendToAll(new Output("[yellow]It is noon."));
+            case 18 -> commService.sendToAll(new Output("[magenta]The sun is setting."));
+            default -> LOGGER.trace("Advanced MUD hour to {}", newHour);
+        }
+    }
+
+    private int advanceTime() {
+        Optional<MudProperty> mudHourOptional = mudPropertyRepository.getByName(PROPERTY_HOUR);
+        MudProperty mudHour = mudHourOptional.orElseGet(() -> new MudProperty(PROPERTY_HOUR, "0"));
+        int intHour = Integer.parseInt(mudHour.getValue()) + 1;
+
+        if (intHour >= 24) {
+            intHour = 0;
+        }
+
+        mudHour.setValue(Integer.toString(intHour));
+
+        mudPropertyRepository.save(mudHour);
+
+        return intHour;
+    }
+}

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/RepositoryBundleTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/RepositoryBundleTest.java
@@ -3,6 +3,7 @@ package com.agonyforge.mud.demo.cli.command;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
 import com.agonyforge.mud.models.dynamodb.repository.MudCharacterRepository;
 import com.agonyforge.mud.models.dynamodb.repository.MudItemRepository;
+import com.agonyforge.mud.models.dynamodb.repository.MudPropertyRepository;
 import com.agonyforge.mud.models.dynamodb.repository.MudRoomRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,6 +14,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
 public class RepositoryBundleTest {
+    @Mock
+    private MudPropertyRepository propertyRepository;
+
     @Mock
     private MudCharacterRepository characterRepository;
 
@@ -25,10 +29,12 @@ public class RepositoryBundleTest {
     @Test
     void testGetters() {
         RepositoryBundle uut = new RepositoryBundle(
+            propertyRepository,
             characterRepository,
             itemRepository,
             roomRepository);
 
+        assertEquals(propertyRepository, uut.getPropertyRepository());
         assertEquals(characterRepository, uut.getCharacterRepository());
         assertEquals(itemRepository, uut.getItemRepository());
         assertEquals(roomRepository, uut.getRoomRepository());

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/TimeCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/TimeCommandTest.java
@@ -1,0 +1,187 @@
+package com.agonyforge.mud.demo.cli.command;
+
+import com.agonyforge.mud.core.cli.Question;
+import com.agonyforge.mud.core.web.model.Input;
+import com.agonyforge.mud.core.web.model.Output;
+import com.agonyforge.mud.core.web.model.WebSocketContext;
+import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.models.dynamodb.impl.MudProperty;
+import com.agonyforge.mud.models.dynamodb.repository.MudPropertyRepository;
+import com.agonyforge.mud.models.dynamodb.service.CommService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.agonyforge.mud.demo.event.WeatherListener.PROPERTY_HOUR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TimeCommandTest {
+    @Mock
+    private RepositoryBundle repositoryBundle;
+
+    @Mock
+    private MudPropertyRepository propertyRepository;
+
+    @Mock
+    private CommService commService;
+
+    @Mock
+    private Question question;
+
+    @Mock
+    private WebSocketContext webSocketContext;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(repositoryBundle.getPropertyRepository()).thenReturn(propertyRepository);
+    }
+
+    @Test
+    void testGetTimeMidnight() {
+        MudProperty mudHour = new MudProperty(PROPERTY_HOUR, "0");
+        Output output = new Output();
+
+        when(propertyRepository.getByName(eq(PROPERTY_HOUR))).thenReturn(Optional.of(mudHour));
+
+        TimeCommand uut = new TimeCommand(repositoryBundle, commService);
+        Question result = uut.execute(question, webSocketContext, List.of("TIME"), new Input("time"), output);
+
+        assertEquals(question, result);
+
+        assertTrue(output.getOutput().get(0).contains("It is midnight"));
+    }
+
+    @Test
+    void testGetTimeNoon() {
+        MudProperty mudHour = new MudProperty(PROPERTY_HOUR, "12");
+        Output output = new Output();
+
+        when(propertyRepository.getByName(eq(PROPERTY_HOUR))).thenReturn(Optional.of(mudHour));
+
+        TimeCommand uut = new TimeCommand(repositoryBundle, commService);
+        Question result = uut.execute(question, webSocketContext, List.of("TIME"), new Input("time"), output);
+
+        assertEquals(question, result);
+
+        assertTrue(output.getOutput().get(0).contains("It is noon"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testGetTimeNight(String hour, String time) {
+        MudProperty mudHour = new MudProperty(PROPERTY_HOUR, hour);
+        Output output = new Output();
+
+        when(propertyRepository.getByName(eq(PROPERTY_HOUR))).thenReturn(Optional.of(mudHour));
+
+        TimeCommand uut = new TimeCommand(repositoryBundle, commService);
+        Question result = uut.execute(question, webSocketContext, List.of("TIME"), new Input("time"), output);
+
+        assertEquals(question, result);
+
+        assertTrue(output.getOutput().get(0).contains("The hour is " + time + " o'clock at night"));
+    }
+
+    private static Stream<Arguments> testGetTimeNight() {
+        return Stream.of(
+            Arguments.of("1", "1"),
+            Arguments.of("2", "2"),
+            Arguments.of("3", "3"),
+            Arguments.of("4", "4"),
+            Arguments.of("5", "5")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testGetTimeMorning(String hour, String time) {
+        MudProperty mudHour = new MudProperty(PROPERTY_HOUR, hour);
+        Output output = new Output();
+
+        when(propertyRepository.getByName(eq(PROPERTY_HOUR))).thenReturn(Optional.of(mudHour));
+
+        TimeCommand uut = new TimeCommand(repositoryBundle, commService);
+        Question result = uut.execute(question, webSocketContext, List.of("TIME"), new Input("time"), output);
+
+        assertEquals(question, result);
+
+        assertTrue(output.getOutput().get(0).contains("The hour is " + time + " o'clock in the morning"));
+    }
+
+    private static Stream<Arguments> testGetTimeMorning() {
+        return Stream.of(
+            Arguments.of("6", "6"),
+            Arguments.of("7", "7"),
+            Arguments.of("8", "8"),
+            Arguments.of("9", "9"),
+            Arguments.of("10", "10")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testGetTimeAfternoon(String hour, String time) {
+        MudProperty mudHour = new MudProperty(PROPERTY_HOUR, hour);
+        Output output = new Output();
+
+        when(propertyRepository.getByName(eq(PROPERTY_HOUR))).thenReturn(Optional.of(mudHour));
+
+        TimeCommand uut = new TimeCommand(repositoryBundle, commService);
+        Question result = uut.execute(question, webSocketContext, List.of("TIME"), new Input("time"), output);
+
+        assertEquals(question, result);
+
+        assertTrue(output.getOutput().get(0).contains("The hour is " + time + " o'clock in the afternoon"));
+    }
+
+    private static Stream<Arguments> testGetTimeAfternoon() {
+        return Stream.of(
+            Arguments.of("13", "1"),
+            Arguments.of("14", "2"),
+            Arguments.of("15", "3"),
+            Arguments.of("16", "4"),
+            Arguments.of("17", "5")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testGetTimeEvening(String hour, String time) {
+        MudProperty mudHour = new MudProperty(PROPERTY_HOUR, hour);
+        Output output = new Output();
+
+        when(propertyRepository.getByName(eq(PROPERTY_HOUR))).thenReturn(Optional.of(mudHour));
+
+        TimeCommand uut = new TimeCommand(repositoryBundle, commService);
+        Question result = uut.execute(question, webSocketContext, List.of("TIME"), new Input("time"), output);
+
+        assertEquals(question, result);
+
+        assertTrue(output.getOutput().get(0).contains("The hour is " + time + " o'clock in the evening"));
+    }
+
+    private static Stream<Arguments> testGetTimeEvening() {
+        return Stream.of(
+            Arguments.of("18", "6"),
+            Arguments.of("19", "7"),
+            Arguments.of("20", "8"),
+            Arguments.of("21", "9"),
+            Arguments.of("22", "10"),
+            Arguments.of("23", "11")
+        );
+    }
+}

--- a/agonyforge-mud-models-dynamodb/src/main/java/com/agonyforge/mud/models/dynamodb/impl/Constants.java
+++ b/agonyforge-mud-models-dynamodb/src/main/java/com/agonyforge/mud/models/dynamodb/impl/Constants.java
@@ -11,6 +11,7 @@ public class Constants {
 
     public static final String KEY_MODIFIED = "lastModified";
 
+    public static final String DB_PROPERTY = "PROPERTY#";
     public static final String DB_USER = "USER#";
     public static final String DB_PC = "PC#";
     public static final String DB_ITEM = "ITEM#";
@@ -22,6 +23,7 @@ public class Constants {
     public static final String SORT_INSTANCE = "INSTANCE#";
     public static final String SORT_COMMAND = "COMMAND#";
 
+    public static final String TYPE_PROPERTY = "PROPERTY";
     public static final String TYPE_USER = "USER";
     public static final String TYPE_SESSION = "SESSION";
     public static final String TYPE_PC = "PC";

--- a/agonyforge-mud-models-dynamodb/src/main/java/com/agonyforge/mud/models/dynamodb/impl/MudProperty.java
+++ b/agonyforge-mud-models-dynamodb/src/main/java/com/agonyforge/mud/models/dynamodb/impl/MudProperty.java
@@ -1,0 +1,77 @@
+package com.agonyforge.mud.models.dynamodb.impl;
+
+import com.agonyforge.mud.models.dynamodb.Persistent;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.agonyforge.mud.models.dynamodb.impl.Constants.DB_PROPERTY;
+import static com.agonyforge.mud.models.dynamodb.impl.Constants.TYPE_PROPERTY;
+
+public class MudProperty implements Persistent {
+    private String name;
+    private String value;
+
+    public MudProperty() {
+        // this method intentionally left blank
+    }
+
+    public MudProperty(String name, String value) {
+        setName(name);
+        setValue(value);
+    }
+
+    @Override
+    public Map<String, AttributeValue> freeze() {
+        Map<String, AttributeValue> map = new HashMap<>();
+        Map<String, AttributeValue> data = new HashMap<>();
+
+        map.put("pk", AttributeValue.builder().s(DB_PROPERTY).build());
+        map.put("sk", AttributeValue.builder().s(getName()).build());
+        map.put("gsi1pk", AttributeValue.builder().s(TYPE_PROPERTY).build());
+
+        data.put("value", AttributeValue.builder().s(getValue()).build());
+        map.put("data", AttributeValue.builder().m(data).build());
+
+        return map;
+    }
+
+    @Override
+    public void thaw(Map<String, AttributeValue> item) {
+        Map<String, AttributeValue> data = item.get("data").m();
+
+        setName(item.get("sk").s());
+        setValue(data.get("value").s());
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MudProperty that = (MudProperty) o;
+        return Objects.equals(name, that.name) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, value);
+    }
+}

--- a/agonyforge-mud-models-dynamodb/src/main/java/com/agonyforge/mud/models/dynamodb/repository/MudPropertyRepository.java
+++ b/agonyforge-mud-models-dynamodb/src/main/java/com/agonyforge/mud/models/dynamodb/repository/MudPropertyRepository.java
@@ -1,0 +1,72 @@
+package com.agonyforge.mud.models.dynamodb.repository;
+
+import com.agonyforge.mud.models.dynamodb.config.DynamoDbProperties;
+import com.agonyforge.mud.models.dynamodb.impl.MudProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.agonyforge.mud.models.dynamodb.impl.Constants.DB_PROPERTY;
+
+@Repository
+public class MudPropertyRepository extends AbstractRepository<MudProperty> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MudPropertyRepository.class);
+
+    @Autowired
+    public MudPropertyRepository(DynamoDbClient dynamoDbClient,
+                                 DynamoDbProperties.TableNames tableNames) {
+        super(dynamoDbClient, tableNames, MudProperty.class);
+    }
+
+    @Override
+    public MudProperty newInstance() {
+        return new MudProperty();
+    }
+
+    public Optional<MudProperty> getByName(String name) {
+        Map<String, Condition> filter = new HashMap<>();
+
+        filter.put("pk", Condition.builder()
+            .comparisonOperator(ComparisonOperator.EQ)
+            .attributeValueList(AttributeValue.builder().s(DB_PROPERTY).build())
+            .build());
+
+        filter.put("sk", Condition.builder()
+            .comparisonOperator(ComparisonOperator.EQ)
+            .attributeValueList(AttributeValue.builder().s(name).build())
+            .build());
+
+        QueryRequest request = QueryRequest.builder()
+            .tableName(tableNames.getTableName())
+            .keyConditions(filter)
+            .build();
+
+        try {
+            QueryResponse response = dynamoDbClient.query(request);
+
+            if (!response.hasItems() || response.items().size() <= 0) {
+                LOGGER.warn("No items returned for {}", name);
+                return Optional.empty();
+            }
+
+            MudProperty item = newInstance();
+            List<Map<String, AttributeValue>> items = response.items();
+
+            item.thaw(items.get(0));
+
+            return Optional.of(item);
+        } catch (DynamoDbException e) {
+            LOGGER.error("DynamoDbException: {}", e.getMessage(), e);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/agonyforge-mud-models-dynamodb/src/main/java/com/agonyforge/mud/models/dynamodb/service/CommService.java
+++ b/agonyforge-mud-models-dynamodb/src/main/java/com/agonyforge/mud/models/dynamodb/service/CommService.java
@@ -40,7 +40,8 @@ public class CommService extends EchoService {
     }
 
     /**
-     * Send a message to all characters that are playing except the sender.
+     * Send a message to all characters that are playing except the sender and specifically excluded
+     * characters.
      *
      * @param wsContext The WebSocketContext of the sender.
      * @param message The message to send.
@@ -53,6 +54,22 @@ public class CommService extends EchoService {
             .stream()
             .filter(ch -> !ch.isPrototype())
             .filter(ch -> !wsContext.getSessionId().equals(ch.getWebSocketSession()))
+            .filter(ch -> !skip.contains(ch))
+            .forEach(ch -> sendTo(ch, message));
+    }
+
+    /**
+     * Send a message to all characters except specifically excluded characters.
+     *
+     * @param message The message to send.
+     * @param except Don't send to these characters.
+     */
+    public void sendToAll(Output message, MudCharacter ... except) {
+        List<MudCharacter> skip = List.of(except);
+
+        characterRepository.getByType(TYPE_PC)
+            .stream()
+            .filter(ch -> !ch.isPrototype())
             .filter(ch -> !skip.contains(ch))
             .forEach(ch -> sendTo(ch, message));
     }

--- a/agonyforge-mud-models-dynamodb/src/test/java/com/agonyforge/mud/models/dynamodb/impl/MudPropertyTest.java
+++ b/agonyforge-mud-models-dynamodb/src/test/java/com/agonyforge/mud/models/dynamodb/impl/MudPropertyTest.java
@@ -1,0 +1,33 @@
+package com.agonyforge.mud.models.dynamodb.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@ExtendWith(MockitoExtension.class)
+public class MudPropertyTest {
+    @Test
+    void testName() {
+        MudProperty uut = new MudProperty();
+        String name = "start.room";
+
+        uut.setName(name);
+
+        assertEquals(name, uut.getName());
+    }
+
+    @Test
+    void testValue() {
+        MudProperty uut = new MudProperty();
+        String value = UUID.randomUUID().toString();
+
+        uut.setValue(value);
+
+        assertEquals(value, uut.getValue());
+    }
+}

--- a/agonyforge-mud-models-dynamodb/src/test/java/com/agonyforge/mud/models/dynamodb/repository/MudPropertyRepositoryTest.java
+++ b/agonyforge-mud-models-dynamodb/src/test/java/com/agonyforge/mud/models/dynamodb/repository/MudPropertyRepositoryTest.java
@@ -1,0 +1,33 @@
+package com.agonyforge.mud.models.dynamodb.repository;
+
+import com.agonyforge.mud.models.dynamodb.impl.MudProperty;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class MudPropertyRepositoryTest extends DynamoDbLocalInitializingTest {
+    @Test
+    void testGetByName() {
+        MudPropertyRepository uut = new MudPropertyRepository(dynamoDbClient, tableNames);
+        MudProperty item = new MudProperty();
+        String name = "test.property";
+        String value = UUID.randomUUID().toString();
+
+        item.setName(name);
+        item.setValue(value);
+
+        uut.save(item);
+
+        Optional<MudProperty> resultOptional = uut.getByName(name);
+        MudProperty result = resultOptional.orElseThrow();
+
+        assertEquals(item.getName(), result.getName());
+        assertEquals(item.getValue(), result.getValue());
+    }
+}

--- a/agonyforge-mud-models-dynamodb/src/test/java/com/agonyforge/mud/models/dynamodb/service/CommServiceTest.java
+++ b/agonyforge-mud-models-dynamodb/src/test/java/com/agonyforge/mud/models/dynamodb/service/CommServiceTest.java
@@ -115,7 +115,7 @@ public class CommServiceTest {
     }
 
     @Test
-    void testSendToAll() {
+    void testSendToAllWebsocket() {
         CommService uut = new CommService(
             applicationContext,
             simpMessagingTemplate,
@@ -126,6 +126,43 @@ public class CommServiceTest {
         Output message = new Output("message");
 
         uut.sendToAll(webSocketContext, message);
+
+        verify(simpMessagingTemplate).convertAndSendToUser(
+            eq(targetPrincipal),
+            eq("/queue/output"),
+            any(Output.class),
+            any(MessageHeaders.class)
+        );
+
+        verify(simpMessagingTemplate).convertAndSendToUser(
+            eq(otherPrincipal),
+            eq("/queue/output"),
+            any(Output.class),
+            any(MessageHeaders.class)
+        );
+
+        verifyNoMoreInteractions(simpMessagingTemplate);
+    }
+
+    @Test
+    void testSendToAll() {
+        CommService uut = new CommService(
+            applicationContext,
+            simpMessagingTemplate,
+            simpUserRegistry,
+            sessionAttributeService,
+            characterRepository);
+
+        Output message = new Output("message");
+
+        uut.sendToAll(message);
+
+        verify(simpMessagingTemplate).convertAndSendToUser(
+            eq(principal),
+            eq("/queue/output"),
+            any(Output.class),
+            any(MessageHeaders.class)
+        );
 
         verify(simpMessagingTemplate).convertAndSendToUser(
             eq(targetPrincipal),


### PR DESCRIPTION
- New MudProperty system for storing persistent string key/value pairs. 
- In-game time is stored in DynamoDB using new MudProperty system. 
- One game hour advances per real minute using the new timer events. 
- Worldwide notifications at noon, 6pm, midnight, and 6am. 
- A new TIME command that tells you the current hour.