### PR TITLE
Some attributes not copying from character prototype to instance

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacter.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacter.java
@@ -192,6 +192,8 @@ public class MudCharacter implements Persistent {
         instance.setName(getName());
         instance.setPronoun(getPronoun());
         instance.setWearSlots(getWearSlots());
+        instance.setSpeciesId(getSpeciesId());
+        instance.setProfessionId(getProfessionId());
 
         Arrays.stream(Stat.values())
             .forEach(stat -> {

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/model/impl/MudCharacterTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/model/impl/MudCharacterTest.java
@@ -24,6 +24,8 @@ public class MudCharacterTest {
         proto.setUser("principal");
         proto.setId(UUID.randomUUID());
         proto.setName("Scion");
+        proto.setSpeciesId(UUID.randomUUID());
+        proto.setProfessionId(UUID.randomUUID());
 
         MudCharacter instance = proto.buildInstance();
 
@@ -37,6 +39,8 @@ public class MudCharacterTest {
         assertEquals(100L, instance.getRoomId());
         assertEquals(proto.getName(), instance.getName());
         assertEquals(proto.getUser(), instance.getUser());
+        assertEquals(proto.getSpeciesId(), instance.getSpeciesId());
+        assertEquals(proto.getProfessionId(), instance.getProfessionId());
         assertThrows(IllegalStateException.class, instance::buildInstance);
     }
 


### PR DESCRIPTION
Species and profession UUIDs were not copied from the prototype to the instance when it was built. If you create a character it would look fine in the login menu. However, once you were in the game and use the `score` command you'd see the wrong species and profession if you did not choose the default ones.