### PR TITLE
pitest breaks on windows because classpath on command line is too long

### DIFF
--- a/agonyforge-mud-core/build.gradle
+++ b/agonyforge-mud-core/build.gradle
@@ -67,6 +67,7 @@ pitest {
     coverageThreshold = 70
     mutationThreshold = 70
     timestampedReports = false
+    useClasspathFile = true
 
     targetClasses = [
         "com.agonyforge.mud.core.*"

--- a/agonyforge-mud-demo/build.gradle
+++ b/agonyforge-mud-demo/build.gradle
@@ -77,6 +77,7 @@ pitest {
     coverageThreshold = 70
     mutationThreshold = 70
     timestampedReports = false
+    useClasspathFile = true
 
     targetClasses = [
         "com.agonyforge.mud.demo.*"


### PR DESCRIPTION
Using a classpath file seems to fix it on Windows, and doesn't break it on OSX.