### PR TITLE
let people restart creating characters if they're incomplete

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterMenuQuestion.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterMenuQuestion.java
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Component;
 import java.security.Principal;
 import java.util.Optional;
 
-import static com.agonyforge.mud.core.config.SessionConfiguration.MUD_CHARACTER;
 import static com.agonyforge.mud.core.config.SessionConfiguration.MUD_PCHARACTER;
 
 @Component
@@ -77,7 +76,7 @@ public class CharacterMenuQuestion extends BaseQuestion {
         getRepositoryBundle().getCharacterPrototypeRepository().findByUsername(principal.getName())
             .forEach(ch -> menuPane.getItems().add(new MenuItem(
                 Integer.toString(menuPane.getItems().size()),
-                ch.getName(),
+                String.format("%s%s", ch.getName(), ch.getComplete() ? "" : " [dred]*[red]INCOMPLETE[dred]*"),
                 ch.getId())));
     }
 }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterProfessionQuestion.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterProfessionQuestion.java
@@ -77,6 +77,9 @@ public class CharacterProfessionQuestion extends BaseQuestion {
                 Arrays.stream(Stat.values()).forEach(stat -> ch.setProfessionStat(stat, profession.getStat(stat)));
                 Arrays.stream(Effort.values()).forEach(effort -> ch.setProfessionEffort(effort, profession.getEffort(effort)));
 
+                // this is the last question, so the character is complete now
+                ch.setComplete(true);
+
                 getRepositoryBundle().getCharacterPrototypeRepository().save(ch);
             }
 

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/event/CharacterJanitor.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/event/CharacterJanitor.java
@@ -37,7 +37,7 @@ public class CharacterJanitor implements ApplicationListener<SessionDisconnectEv
         SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.wrap(event.getMessage());
         Map<String, Object> attributes = headerAccessor.getSessionAttributes();
 
-        if (attributes != null) {
+        if (attributes != null && attributes.containsKey(MUD_CHARACTER)) {
             Long chId = (Long)attributes.get(MUD_CHARACTER);
             Optional<MudCharacter> instanceOptional = characterRepository.findById(chId);
 

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacterPrototype.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacterPrototype.java
@@ -14,6 +14,7 @@ public class MudCharacterPrototype extends Persistent {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
+    private Boolean isComplete = false;
     private String username;
     private String name;
     private Pronoun pronoun;
@@ -72,6 +73,10 @@ public class MudCharacterPrototype extends Persistent {
     }
 
     public MudCharacter buildInstance() {
+        if (getComplete() == null || !getComplete()) {
+            throw new IllegalStateException("Cannot build an incomplete instance of a character.");
+        }
+
         MudCharacter instance = new MudCharacter();
 
         instance.setPrototypeId(getId());
@@ -104,6 +109,14 @@ public class MudCharacterPrototype extends Persistent {
 
     public void setId(Long id) {
         this.id = id;
+    }
+
+    public Boolean getComplete() {
+        return isComplete;
+    }
+
+    public void setComplete(Boolean complete) {
+        isComplete = complete;
     }
 
     public String getUsername() {

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/login/CharacterViewQuestionTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/login/CharacterViewQuestionTest.java
@@ -121,6 +121,7 @@ public class CharacterViewQuestionTest {
 
         when(wsContext.getAttributes()).thenReturn(attributes);
         when(characterPrototypeRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
+        when(ch.getComplete()).thenReturn(true);
         when(ch.getName()).thenReturn(characterName);
         when(ch.getPronoun()).thenReturn(Pronoun.SHE);
         when(ch.getSpeciesId()).thenReturn(DEFAULT_SPECIES_ID);
@@ -182,6 +183,7 @@ public class CharacterViewQuestionTest {
         when(wsContext.getAttributes()).thenReturn(attributes);
         when(wsContext.getSessionId()).thenReturn(wsSessionId);
 
+        when(ch.getComplete()).thenReturn(true);
         when(ch.buildInstance()).thenReturn(chInstance);
         when(characterPrototypeRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
         when(characterRepository.save(any(MudCharacter.class))).thenAnswer(i -> i.getArguments()[0]);
@@ -232,6 +234,15 @@ public class CharacterViewQuestionTest {
 
     @Test
     void testAnswerUnknown() {
+        Long chId = random.nextLong();
+        String wsSessionId = UUID.randomUUID().toString();
+        Map<String, Object> attributes = new HashMap<>();
+
+        attributes.put(MUD_PCHARACTER, chId);
+
+        when(wsContext.getAttributes()).thenReturn(attributes);
+        when(characterPrototypeRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
+
         CharacterViewQuestion uut = new CharacterViewQuestion(applicationContext, repositoryBundle, commService, sessionAttributeService, characterSheetFormatter);
         Response result = uut.answer(wsContext, new Input("x"));
         Output output = result.getFeedback().orElseThrow();

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/model/impl/MudCharacterTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/model/impl/MudCharacterTest.java
@@ -21,6 +21,7 @@ public class MudCharacterTest {
     void testBuildInstance() {
         MudCharacterPrototype proto = new MudCharacterPrototype();
 
+        proto.setComplete(true);
         proto.setUsername("principal");
         proto.setId(random.nextLong());
         proto.setName("Scion");
@@ -55,6 +56,7 @@ public class MudCharacterTest {
         MudCharacter uutInst;
         String user = "user";
 
+        uut.setComplete(true);
         uut.setUsername(user);
         uutInst = uut.buildInstance();
 
@@ -69,6 +71,7 @@ public class MudCharacterTest {
         String user = UUID.randomUUID().toString();
         String webSocketSession = "webSocketSession";
 
+        uut.setComplete(true);
         uut.setUsername(user);
         uutInst = uut.buildInstance();
 
@@ -84,6 +87,7 @@ public class MudCharacterTest {
         MudCharacter uutInst;
         Long roomId = 100L;
 
+        uut.setComplete(true);
         uutInst = uut.buildInstance();
         uutInst.setRoomId(roomId);
 
@@ -96,6 +100,7 @@ public class MudCharacterTest {
         MudCharacter uutInst;
         Long roomId = 100L;
 
+        uut.setComplete(true);
         uutInst = uut.buildInstance();
         uutInst.setRoomId(roomId);
 


### PR DESCRIPTION
It's not really re-entering the editor so much as starting it over, but it fixes #273 by marking characters as "incomplete" if the session is interrupted before the character creation is done. It won't let you play the game with an incomplete character, but it will let you jump back into the editor to re-allocate your points and stuff.