### PR TITLE
Fix lazy loading error

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomExitsQuestion.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomExitsQuestion.java
@@ -122,11 +122,10 @@ public class RoomExitsQuestion extends BaseQuestion {
 
     private MudRoom getRoomModel(WebSocketContext wsContext, MudCharacter ch) {
         if (!wsContext.getAttributes().containsKey(REDIT_MODEL)) {
-            MudRoom room = getRepositoryBundle().getRoomRepository().findById(ch.getRoomId()).orElseThrow();
-            wsContext.getAttributes().put(REDIT_MODEL, room);
+            wsContext.getAttributes().put(REDIT_MODEL, ch.getRoomId());
         }
 
-        return (MudRoom)wsContext.getAttributes().get(REDIT_MODEL);
+        return getRepositoryBundle().getRoomRepository().findById(ch.getRoomId()).orElseThrow();
     }
 
     void populateMenuItems(MudRoom room) {


### PR DESCRIPTION
The room editor was set up to load the Room to be edited and store the entire object in the session attributes. That worked fine for DynamoDB where there aren't any transactions but with Hibernate the object became detached when the user typed the next command into the editor. This changes it so that only the room's ID is stored in the session, and the room itself is fetched fresh for each command.