### PR TITLE
Role Framework

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterNameQuestion.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterNameQuestion.java
@@ -6,6 +6,8 @@ import com.agonyforge.mud.demo.cli.question.BaseQuestion;
 import com.agonyforge.mud.demo.model.constant.WearSlot;
 import com.agonyforge.mud.demo.model.constant.Pronoun;
 import com.agonyforge.mud.demo.model.impl.MudCharacterPrototype;
+import com.agonyforge.mud.demo.model.impl.Role;
+import com.agonyforge.mud.demo.model.repository.RoleRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.agonyforge.mud.core.cli.Question;
@@ -18,6 +20,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
+import java.util.Set;
 
 import static com.agonyforge.mud.core.config.SessionConfiguration.MUD_PCHARACTER;
 
@@ -25,10 +28,15 @@ import static com.agonyforge.mud.core.config.SessionConfiguration.MUD_PCHARACTER
 public class CharacterNameQuestion extends BaseQuestion {
     private static final Logger LOGGER = LoggerFactory.getLogger(CharacterNameQuestion.class);
 
+    private final RoleRepository roleRepository;
+
     @Autowired
     public CharacterNameQuestion(ApplicationContext applicationContext,
-                                 RepositoryBundle repositoryBundle) {
+                                 RepositoryBundle repositoryBundle,
+                                 RoleRepository roleRepository) {
         super(applicationContext, repositoryBundle);
+
+        this.roleRepository = roleRepository;
     }
 
     @Override
@@ -49,9 +57,11 @@ public class CharacterNameQuestion extends BaseQuestion {
         }
 
         MudCharacterPrototype ch = new MudCharacterPrototype();
+        Role playerRole = roleRepository.findByName("Player").orElseThrow();
 
         ch.setUsername(wsContext.getPrincipal().getName());
         ch.setName(input.getInput());
+        ch.setRoles(Set.of(playerRole));
         ch.setPronoun(Pronoun.THEY);
         ch.setWearSlots(Arrays.stream(WearSlot.values()).toList());
 

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
@@ -1,78 +1,122 @@
 package com.agonyforge.mud.demo.config;
 
 import com.agonyforge.mud.demo.model.impl.CommandReference;
+import com.agonyforge.mud.demo.model.impl.Role;
 import com.agonyforge.mud.demo.model.repository.CommandRepository;
 
+import com.agonyforge.mud.demo.model.repository.RoleRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Component
 public class CommandLoader {
     private static final Logger LOGGER = LoggerFactory.getLogger(CommandLoader.class);
 
     private final CommandRepository commandRepository;
+    private final RoleRepository roleRepository;
 
     @Autowired
-    public CommandLoader(CommandRepository commandRepository) {
+    public CommandLoader(CommandRepository commandRepository, RoleRepository roleRepository) {
         this.commandRepository = commandRepository;
+        this.roleRepository = roleRepository;
     }
 
     @PostConstruct
     public void loadCommands() {
         if (commandRepository.findAll().isEmpty()) {
-            List<CommandReference> refs = new ArrayList<>();
+            Map<String, CommandReference> refs = new HashMap<>();
 
-            refs.add(new CommandReference(1, "NORTH", "northCommand"));
-            refs.add(new CommandReference(1, "EAST", "eastCommand"));
-            refs.add(new CommandReference(1, "SOUTH", "southCommand"));
-            refs.add(new CommandReference(1, "WEST", "westCommand"));
-            refs.add(new CommandReference(1, "UP", "upCommand"));
-            refs.add(new CommandReference(1, "DOWN", "downCommand"));
+            refs.put("NORTH", new CommandReference(1, "NORTH", "northCommand"));
+            refs.put("EAST", new CommandReference(1, "EAST", "eastCommand"));
+            refs.put("SOUTH", new CommandReference(1, "SOUTH", "southCommand"));
+            refs.put("WEST", new CommandReference(1, "WEST", "westCommand"));
+            refs.put("UP", new CommandReference(1, "UP", "upCommand"));
+            refs.put("DOWN", new CommandReference(1, "DOWN", "downCommand"));
 
-            refs.add(new CommandReference(2, "NORTHEAST", "northeastCommand"));
-            refs.add(new CommandReference(2, "NORTHWEST", "northwestCommand"));
-            refs.add(new CommandReference(2, "SOUTHEAST", "southeastCommand"));
-            refs.add(new CommandReference(2, "SOUTHWEST", "southwestCommand"));
-            refs.add(new CommandReference(2, "NE", "northeastCommand"));
-            refs.add(new CommandReference(2, "NW", "northwestCommand"));
-            refs.add(new CommandReference(2, "SE", "southeastCommand"));
-            refs.add(new CommandReference(2, "SW", "southwestCommand"));
+            refs.put("NORTHEAST", new CommandReference(2, "NORTHEAST", "northeastCommand"));
+            refs.put("NORTHWEST", new CommandReference(2, "NORTHWEST", "northwestCommand"));
+            refs.put("SOUTHEAST", new CommandReference(2, "SOUTHEAST", "southeastCommand"));
+            refs.put("SOUTHWEST", new CommandReference(2, "SOUTHWEST", "southwestCommand"));
+            refs.put("NE", new CommandReference(2, "NE", "northeastCommand"));
+            refs.put("NW", new CommandReference(2, "NW", "northwestCommand"));
+            refs.put("SE", new CommandReference(2, "SE", "southeastCommand"));
+            refs.put("SW", new CommandReference(2, "SW", "southwestCommand"));
 
-            refs.add(new CommandReference(5, "LOOK", "lookCommand"));
-            refs.add(new CommandReference(5, "WHO", "whoCommand"));
-            refs.add(new CommandReference(5, "SCORE", "scoreCommand"));
-            refs.add(new CommandReference(5, "EQUIPMENT", "equipmentCommand"));
-            refs.add(new CommandReference(5, "INVENTORY", "inventoryCommand"));
+            refs.put("LOOK", new CommandReference(5, "LOOK", "lookCommand"));
+            refs.put("WHO", new CommandReference(5, "WHO", "whoCommand"));
+            refs.put("SCORE", new CommandReference(5, "SCORE", "scoreCommand"));
+            refs.put("EQUIPMENT", new CommandReference(5, "EQUIPMENT", "equipmentCommand"));
+            refs.put("INVENTORY", new CommandReference(5, "INVENTORY", "inventoryCommand"));
 
-            refs.add(new CommandReference(10, "DROP", "dropCommand"));
-            refs.add(new CommandReference(10, "GET", "getCommand"));
-            refs.add(new CommandReference(10, "GIVE", "giveCommand"));
-            refs.add(new CommandReference(10, "REMOVE", "removeCommand"));
-            refs.add(new CommandReference(10, "WEAR", "wearCommand"));
-            refs.add(new CommandReference(10, "GOSSIP", "gossipCommand"));
-            refs.add(new CommandReference(10, "SAY", "sayCommand"));
-            refs.add(new CommandReference(10, "SHOUT", "shoutCommand"));
-            refs.add(new CommandReference(10, "TELL", "tellCommand"));
-            refs.add(new CommandReference(10, "WHISPER", "whisperCommand"));
+            refs.put("DROP", new CommandReference(10, "DROP", "dropCommand"));
+            refs.put("GET", new CommandReference(10, "GET", "getCommand"));
+            refs.put("GIVE", new CommandReference(10, "GIVE", "giveCommand"));
+            refs.put("REMOVE", new CommandReference(10, "REMOVE", "removeCommand"));
+            refs.put("WEAR", new CommandReference(10, "WEAR", "wearCommand"));
+            refs.put("GOSSIP", new CommandReference(10, "GOSSIP", "gossipCommand"));
+            refs.put("SAY", new CommandReference(10, "SAY", "sayCommand"));
+            refs.put("SHOUT", new CommandReference(10, "SHOUT", "shoutCommand"));
+            refs.put("TELL", new CommandReference(10, "TELL", "tellCommand"));
+            refs.put("WHISPER", new CommandReference(10, "WHISPER", "whisperCommand"));
 
-            refs.add(new CommandReference(15, "ROLL", "rollCommand"));
-            refs.add(new CommandReference(15, "TIME", "timeCommand"));
+            refs.put("ROLL", new CommandReference(15, "ROLL", "rollCommand"));
+            refs.put("TIME", new CommandReference(15, "TIME", "timeCommand"));
 
-            refs.add(new CommandReference(20, "REDIT", "roomEditorCommand"));
-            refs.add(new CommandReference(20, "IEDIT", "itemEditorCommand"));
+            refs.put("REDIT", new CommandReference(20, "REDIT", "roomEditorCommand"));
+            refs.put("IEDIT", new CommandReference(20, "IEDIT", "itemEditorCommand"));
 
-            refs.add(new CommandReference(30, "CREATE", "createCommand"));
-            refs.add(new CommandReference(30, "PURGE", "purgeCommand"));
+            refs.put("CREATE", new CommandReference(30, "CREATE", "createCommand"));
+            refs.put("PURGE", new CommandReference(30, "PURGE", "purgeCommand"));
 
             LOGGER.info("Creating command references");
-            commandRepository.saveAll(refs);
+            commandRepository.saveAll(refs.values());
+
+            Role player = new Role();
+
+            player.setName("Player");
+            player.getCommands().add(refs.get("NORTH"));
+            player.getCommands().add(refs.get("EAST"));
+            player.getCommands().add(refs.get("SOUTH"));
+            player.getCommands().add(refs.get("WEST"));
+            player.getCommands().add(refs.get("UP"));
+            player.getCommands().add(refs.get("DOWN"));
+
+            player.getCommands().add(refs.get("NORTHEAST"));
+            player.getCommands().add(refs.get("NORTHWEST"));
+            player.getCommands().add(refs.get("SOUTHEAST"));
+            player.getCommands().add(refs.get("SOUTHWEST"));
+            player.getCommands().add(refs.get("NE"));
+            player.getCommands().add(refs.get("NW"));
+            player.getCommands().add(refs.get("SE"));
+            player.getCommands().add(refs.get("SW"));
+
+            player.getCommands().add(refs.get("LOOK"));
+            player.getCommands().add(refs.get("WHO"));
+            player.getCommands().add(refs.get("SCORE"));
+
+            player.getCommands().add(refs.get("EQUIPMENT"));
+            player.getCommands().add(refs.get("INVENTORY"));
+            player.getCommands().add(refs.get("DROP"));
+            player.getCommands().add(refs.get("GET"));
+            player.getCommands().add(refs.get("GIVE"));
+            player.getCommands().add(refs.get("REMOVE"));
+            player.getCommands().add(refs.get("WEAR"));
+
+            player.getCommands().add(refs.get("GOSSIP"));
+            player.getCommands().add(refs.get("SAY"));
+            player.getCommands().add(refs.get("SHOUT"));
+            player.getCommands().add(refs.get("TELL"));
+            player.getCommands().add(refs.get("WHISPER"));
+
+            roleRepository.save(player);
         }
     }
 }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacter.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacter.java
@@ -6,12 +6,7 @@ import com.agonyforge.mud.demo.model.constant.Stat;
 import com.agonyforge.mud.demo.model.constant.WearSlot;
 import jakarta.persistence.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 @Entity
 @Table(name = "mud_character")
@@ -25,6 +20,9 @@ public class MudCharacter extends Persistent {
     private Long roomId;
     private String name;
     private Pronoun pronoun;
+
+    @ManyToMany
+    private Set<Role> roles = new HashSet<>();
 
     @ElementCollection
     @CollectionTable(name = "mud_character_wearslot_mapping",
@@ -139,6 +137,14 @@ public class MudCharacter extends Persistent {
 
     public void setPronoun(Pronoun pronoun) {
         this.pronoun = pronoun;
+    }
+
+    public Set<Role> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<Role> roles) {
+        this.roles = roles;
     }
 
     public List<WearSlot> getWearSlots() {

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacterPrototype.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacterPrototype.java
@@ -19,6 +19,9 @@ public class MudCharacterPrototype extends Persistent {
     private String name;
     private Pronoun pronoun;
 
+    @ManyToMany()
+    private Set<Role> roles = new HashSet<>();
+
     @ElementCollection
     @CollectionTable(name = "mud_pcharacter_wearslot_mapping",
     joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
@@ -83,6 +86,7 @@ public class MudCharacterPrototype extends Persistent {
         instance.setUsername(getUsername());
         instance.setName(getName());
         instance.setPronoun(getPronoun());
+        instance.setRoles(getRoles());
         instance.setWearSlots(getWearSlots());
         instance.setSpeciesId(getSpeciesId());
         instance.setProfessionId(getProfessionId());
@@ -141,6 +145,14 @@ public class MudCharacterPrototype extends Persistent {
 
     public void setPronoun(Pronoun pronoun) {
         this.pronoun = pronoun;
+    }
+
+    public Set<Role> getRoles() {
+        return new HashSet<>(roles);
+    }
+
+    public void setRoles(Set<Role> roles) {
+        this.roles = new HashSet<>(roles);
     }
 
     public List<WearSlot> getWearSlots() {

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/Role.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/Role.java
@@ -1,0 +1,55 @@
+package com.agonyforge.mud.demo.model.impl;
+
+import jakarta.persistence.*;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "mud_role")
+public class Role extends Persistent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    private String name;
+
+    @OneToMany
+    private Set<CommandReference> commands = new HashSet<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Set<CommandReference> getCommands() {
+        return commands;
+    }
+
+    public void setCommands(Set<CommandReference> commands) {
+        this.commands = commands;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Role role = (Role) o;
+        return Objects.equals(id, role.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/repository/CommandRepository.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/repository/CommandRepository.java
@@ -1,10 +1,13 @@
 package com.agonyforge.mud.demo.model.repository;
 
 import com.agonyforge.mud.demo.model.impl.CommandReference;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CommandRepository extends JpaRepository<CommandReference, String> {
-
+    Optional<CommandReference> findFirstByNameStartingWith(String name, Sort sort);
 }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/repository/RoleRepository.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/repository/RoleRepository.java
@@ -1,0 +1,12 @@
+package com.agonyforge.mud.demo.model.repository;
+
+import com.agonyforge.mud.demo.model.impl.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Optional<Role> findByName(String name);
+}


### PR DESCRIPTION
fixes #362 

This is the start of a role framework. If your character's ID equals 1 you're the superuser. The permissions check doesn't apply and you can run every command in the game. The database ensures there can only ever be one character with superuser powers, and it's always the first character to be created. Every other character is checked for a role that contains the command they are trying to run. As long as one or more roles provides the command, you can run it. Otherwise the game pretends like the command didn't exist.

In this initial implementation I have it automatically create a single role and assign it to everyone. In the future there will be an editor to create and edit roles beyond "Player" and a command to add or remove them for other characters. That way you can have players with different sets of permissions, and even more than one role at a time.

* Created a `Role` entity that contains a set of commands and a name. This is used to define what commands the role will enable.
* Updated `CommandQuestion` to check for permission to run each command, or return "Huh?" as if it did not exist.
* Updated `CommandLoader` to create a role named "Player" and put the basic commands in it.
* Updated `CharacterNameQuestion` to provide the "Player" role to new characters as they are created.