### PR TITLE
pipe access logs into the regular mud logs

### DIFF
--- a/agonyforge-mud-core/build.gradle
+++ b/agonyforge-mud-core/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
     implementation 'com.hazelcast:hazelcast:5.5.0'
     implementation 'io.projectreactor.netty:reactor-netty:1.2.1'
+    implementation 'ch.qos.logback.access:logback-access-tomcat:2.0.5'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-freemarker'

--- a/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/config/TomcatConfiguration.java
+++ b/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/config/TomcatConfiguration.java
@@ -1,0 +1,18 @@
+package com.agonyforge.mud.core.config;
+
+import ch.qos.logback.access.tomcat.LogbackValve;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TomcatConfiguration implements WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+    @Override
+    public void customize(TomcatServletWebServerFactory factory) {
+        LogbackValve valve = new LogbackValve();
+        valve.setQuiet(false);
+
+        factory.addEngineValves(valve);
+        factory.addContextValves(valve);
+    }
+}

--- a/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/logging/AccessLogAppender.java
+++ b/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/logging/AccessLogAppender.java
@@ -1,0 +1,38 @@
+package com.agonyforge.mud.core.logging;
+
+import ch.qos.logback.access.common.PatternLayoutEncoder;
+import ch.qos.logback.access.common.spi.IAccessEvent;
+import ch.qos.logback.core.AppenderBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.Charset;
+
+public class AccessLogAppender extends AppenderBase<IAccessEvent> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AccessLogAppender.class);
+
+    PatternLayoutEncoder encoder;
+
+    @Override
+    public void start() {
+        if (this.encoder == null) {
+            addError(String.format("No encoder set for the appender named [%s]", name));
+            return;
+        }
+
+        encoder.start();
+        super.start();
+    }
+
+    public void append(IAccessEvent event) {
+        LOGGER.debug("Access Log: {}", new String(encoder.encode(event), Charset.defaultCharset()).trim());
+    }
+
+    public PatternLayoutEncoder getEncoder() {
+        return encoder;
+    }
+
+    public void setEncoder(PatternLayoutEncoder encoder) {
+        this.encoder = encoder;
+    }
+}

--- a/agonyforge-mud-core/src/main/resources/conf/logback-access.xml
+++ b/agonyforge-mud-core/src/main/resources/conf/logback-access.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <conversionRule conversionWord="h" class="ch.qos.logback.access.common.pattern.RemoteHostConverter" />
+    <conversionRule conversionWord="l" class="ch.qos.logback.access.common.pattern.NAConverter" />
+    <conversionRule conversionWord="u" class="ch.qos.logback.access.common.pattern.RemoteUserConverter" />
+    <conversionRule conversionWord="t" class="ch.qos.logback.access.common.pattern.DateConverter" />
+    <conversionRule conversionWord="r" class="ch.qos.logback.access.common.pattern.RequestURLConverter" />
+    <conversionRule conversionWord="s" class="ch.qos.logback.access.common.pattern.StatusCodeConverter" />
+    <conversionRule conversionWord="b" class="ch.qos.logback.access.common.pattern.ContentLengthConverter" />
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml" />
+
+    <appender name="CONSOLE" class="com.agonyforge.mud.core.logging.AccessLogAppender" >
+        <encoder class="ch.qos.logback.access.common.PatternLayoutEncoder">
+            <pattern>%h "%r" %s %b</pattern>
+        </encoder>
+    </appender>
+
+    <appender-ref ref="CONSOLE"/>
+</configuration>

--- a/agonyforge-mud-demo/build.gradle
+++ b/agonyforge-mud-demo/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.postgresql:postgresql:42.7.4'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation 'com.hazelcast:hazelcast:5.5.0'
+    implementation 'ch.qos.logback.access:logback-access-tomcat:2.0.5'
 
     implementation 'org.webjars:webjars-locator:0.52'
     implementation 'org.webjars:bootstrap:5.3.3'

--- a/agonyforge-mud-demo/src/main/resources/application.yaml
+++ b/agonyforge-mud-demo/src/main/resources/application.yaml
@@ -6,9 +6,24 @@ spring:
 #        show_sql: true
 #        use_sql_comments: true
 #        format_sql: true
-#
-#logging:
-#  level:
+
+server:
+  tomcat:
+    accesslog:
+      enabled: true
+      buffered: false
+    redirect-context-root: false
+
+logging:
+  level:
+    com:
+      agonyforge:
+        mud:
+          core:
+            logging: DEBUG
 #    org:
+#      apache:
+#        tomcat: DEBUG
+#        catalina: DEBUG
 #      hibernate:
 #        type: TRACE


### PR DESCRIPTION
This was stupidly difficult to do, but the result is actually pretty nice.

There's a `LogbackValve` from logback that you can attach to Tomcat to get the access logs. Logback assumes you're going to have a high volume of logs, which is generally valid but not so much for this use case. There are two different kinds of logs, and of course the regular console appender doesn't work for access logs and there isn't a built in one due to the assumption I mentioned.

So... I wrote my own appender and a configuration that `LogbackValve` reads. My appender pipes messages from the valve into the MUD's regular logger with some nice formatting so it looks like all the other log messages. You can easily control it with configuration in `application.yaml`. It shouldn't generate a ton of spam in the logs because once users are connected to websocket there are no more access logs. Since there's not a whole lot of site aside from the websocket part... not many logs.

This will hopefully be helpful tomorrow when I go back to trying to debug why connections into my server from the public internet aren't working. It'll also make a good article for the blog.