### PR TITLE
Fix role bugs

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/WhoCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/WhoCommand.java
@@ -30,7 +30,7 @@ public class WhoCommand extends AbstractCommand {
             .append("[black]=== [white]Who is Playing [black]===")
             .append("");
 
-        characters.forEach(ch -> output.append("[%s]%s", ch.getId() == 1L ? "yellow" : "white", ch.getName()));
+        characters.forEach(ch -> output.append("[%s]%s", ch.getPrototypeId() == 1L ? "yellow" : "white", ch.getName()));
 
         output
             .append("")

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/CommandQuestion.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/CommandQuestion.java
@@ -79,7 +79,7 @@ public class CommandQuestion extends BaseQuestion {
             Command command = applicationContext.getBean(ref.getBeanName(), Command.class);
             MudCharacter ch = getCharacter(webSocketContext, output).orElseThrow();
 
-            if (1L == ch.getId() || ch.getRoles().stream().anyMatch(role -> role.getCommands().contains(ref))) {
+            if (1L == ch.getPrototypeId() || ch.getRoles().stream().anyMatch(role -> role.getCommands().contains(ref))) {
                 Question next = command.execute(this, webSocketContext, tokens, input, output);
                 return new Response(next, output);
             }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterSheetFormatter.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterSheetFormatter.java
@@ -59,7 +59,7 @@ public final class CharacterSheetFormatter {
         MudProfession profession = professionRepository.findById(ch.getProfessionId() != null ? ch.getProfessionId() : DEFAULT_PROFESSION_ID).orElseThrow();
 
         output.append("[dcyan]CHARACTER SHEET");
-        output.append("[default]Name: [%s]%s", ch.getId() == 1L ? "yellow" : "cyan", ch.getName());
+        output.append("[default]Name: [%s]%s", ch.getPrototypeId() == 1L ? "yellow" : "cyan", ch.getName());
         output.append("[default]Pronouns: [cyan]%s/%s", ch.getPronoun().getSubject(), ch.getPronoun().getObject());
         output.append("[default]Species: [cyan]%s", species.getName());
         output.append("[default]Profession: [cyan]%s", profession.getName());

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
@@ -11,9 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Component
@@ -115,6 +113,8 @@ public class CommandLoader {
             player.getCommands().add(refs.get("SHOUT"));
             player.getCommands().add(refs.get("TELL"));
             player.getCommands().add(refs.get("WHISPER"));
+
+            player.getCommands().add(refs.get("TIME"));
 
             roleRepository.save(player);
         }

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/ingame/CommandQuestionTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/ingame/CommandQuestionTest.java
@@ -113,7 +113,7 @@ public class CommandQuestionTest {
 
         when(commandReference.getBeanName()).thenReturn("testCommand");
 
-        when(ch.getId()).thenReturn(1L);
+        when(ch.getPrototypeId()).thenReturn(1L);
         when(characterRepository.findById(any())).thenReturn(Optional.of(ch));
         when(commandRepository.findFirstByNameStartingWith(eq("TEST"), eq(Sort.by(Sort.Order.asc("priority"))))).thenReturn(Optional.of(commandReference));
         when(applicationContext.getBean(eq("testCommand"), eq(Command.class))).thenReturn(command);
@@ -136,7 +136,7 @@ public class CommandQuestionTest {
 
         when(commandReference.getBeanName()).thenReturn("testCommand");
 
-        when(ch.getId()).thenReturn(2L);
+        when(ch.getPrototypeId()).thenReturn(2L);
         when(characterRepository.findById(any())).thenReturn(Optional.of(ch));
         when(commandRepository.findFirstByNameStartingWith(eq("TEST"), eq(Sort.by(Sort.Order.asc("priority"))))).thenReturn(Optional.of(commandReference));
         when(applicationContext.getBean(eq("testCommand"), eq(Command.class))).thenReturn(command);
@@ -229,7 +229,7 @@ public class CommandQuestionTest {
 
         when(commandReference.getBeanName()).thenReturn("testCommand");
 
-        when(ch.getId()).thenReturn(1L);
+        when(ch.getPrototypeId()).thenReturn(1L);
         when(characterRepository.findById(any())).thenReturn(Optional.of(ch));
         when(commandRepository.findFirstByNameStartingWith(eq("QUOTED STRING"), eq(Sort.by(Sort.Order.asc("priority"))))).thenReturn(Optional.of(commandReference));
         when(applicationContext.getBean(eq("testCommand"), eq(Command.class))).thenReturn(command);


### PR DESCRIPTION
In several cases it was checking the character's ID instead of their prototype ID for superuser access. That meant that the first character to log into the game was the superuser but after they log out and log back in they could no longer use the extra commands.

Also the TIME command was missing from the Player role.