### PR TITLE
character menu was getting appended to the greeting

### DIFF
--- a/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/web/controller/WebSocketController.java
+++ b/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/web/controller/WebSocketController.java
@@ -72,7 +72,9 @@ public class WebSocketController {
             httpSessionId,
             wsContext.getPrincipal().getName());
 
-        return greeting.append(initialQuestion.prompt(wsContext));
+        return new Output()
+            .append(greeting)
+            .append(initialQuestion.prompt(wsContext));
     }
 
     @MessageMapping("/input")


### PR DESCRIPTION
I had noticed this happening before but it got more prominent recently while I've been testing roles with multiple characters. What happened was I made a mistake in the WebSocketController and appended the character menu to the greeting itself each time somebody logged in, so it would continue to grow with each connection.

This fix makes a new `Output`, then appends the greeting and the menu to that so it's clean each time.