### PR TITLE
Configurable header name for remote IP resolution

### DIFF
--- a/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/config/RemoteIpHandshakeInterceptor.java
+++ b/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/config/RemoteIpHandshakeInterceptor.java
@@ -2,6 +2,7 @@ package com.agonyforge.mud.core.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.web.socket.WebSocketHandler;
@@ -18,12 +19,17 @@ public class RemoteIpHandshakeInterceptor implements HandshakeInterceptor {
     public static final String SESSION_REMOTE_IP_KEY = "MUD.REMOTE.IP";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RemoteIpHandshakeInterceptor.class);
-    private static final String X_FORWARDED_FOR_HEADER = "x-forwarded-for"; // TODO externalize configuration, allow a list of headers and trusted proxies
+
+    private String remoteIpHeader;
+
+    public RemoteIpHandshakeInterceptor(String remoteIpHeader) {
+        this.remoteIpHeader = remoteIpHeader;
+    }
 
     @Override
     public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) {
         Optional
-            .ofNullable(request.getHeaders().get(X_FORWARDED_FOR_HEADER))
+            .ofNullable(request.getHeaders().get(remoteIpHeader))
             .ifPresent(headers -> headers.forEach(header -> Arrays.stream(header.split(","))
                 .map(address -> {
                     try {

--- a/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/config/RemoteIpHandshakeInterceptor.java
+++ b/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/config/RemoteIpHandshakeInterceptor.java
@@ -2,7 +2,6 @@ package com.agonyforge.mud.core.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.web.socket.WebSocketHandler;

--- a/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/config/RemoteIpHandshakeInterceptor.java
+++ b/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/config/RemoteIpHandshakeInterceptor.java
@@ -19,7 +19,7 @@ public class RemoteIpHandshakeInterceptor implements HandshakeInterceptor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RemoteIpHandshakeInterceptor.class);
 
-    private String remoteIpHeader;
+    private final String remoteIpHeader;
 
     public RemoteIpHandshakeInterceptor(String remoteIpHeader) {
         this.remoteIpHeader = remoteIpHeader;
@@ -34,9 +34,7 @@ public class RemoteIpHandshakeInterceptor implements HandshakeInterceptor {
                     try {
                         InetAddress inetAddress = InetAddress.getByName(address);
 
-                        if (!inetAddress.isSiteLocalAddress()) {
-                            return inetAddress.getHostAddress();
-                        }
+                        return inetAddress.getHostAddress();
                     } catch (UnknownHostException e) {
                         LOGGER.debug("Failed to resolve IP for address: {}", address);
                     }

--- a/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/config/WebSocketBrokerConfiguration.java
+++ b/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/config/WebSocketBrokerConfiguration.java
@@ -27,6 +27,9 @@ public class WebSocketBrokerConfiguration extends AbstractSessionWebSocketMessag
     @Value("#{environment.CORS_ALLOWED_ORIGINS}")
     private String corsAllowedOrigins;
 
+    @Value("#{environment.PROXY_REMOTE_IP_HEADER}")
+    private String remoteIpHeader;
+
     @Autowired
     public WebSocketBrokerConfiguration(MqBrokerProperties brokerProperties) {
         this.brokerProperties = brokerProperties;
@@ -53,7 +56,7 @@ public class WebSocketBrokerConfiguration extends AbstractSessionWebSocketMessag
             .setInterceptors(
                 httpSessionHandshakeInterceptor,
                 new SessionIdCopyingHandshakeInterceptor(),
-                new RemoteIpHandshakeInterceptor());
+                new RemoteIpHandshakeInterceptor(remoteIpHeader));
     }
 
     @Override

--- a/mud.EXAMPLE.env
+++ b/mud.EXAMPLE.env
@@ -1,5 +1,6 @@
 # Configuration variables for your site.
 CORS_ALLOWED_ORIGINS=http://your.url.here
+PROXY_REMOTE_IP_HEADER=X-Forwarded-For
 
 # These variables tell the MUD how to connect to PostgreSQL.
 #


### PR DESCRIPTION
Different reverse proxies use different header names to pass the remote IP address in to the service behind the proxy. The name of the header is not strictly standardized. Sometimes it's `x-forwarded-for`, sometimes `X-Forwarded-For`, `X-Real-IP` or any number of other values. This change makes it so you can configure the header name in your `mud.env` to match what your proxy is sending.