### PR TITLE
Connection Maintenance

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/LookCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/LookCommand.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Component
@@ -40,16 +41,22 @@ public class LookCommand extends AbstractCommand {
             .stream()
             .filter(target -> !target.equals(ch))
             .forEach(target -> {
-                String question = (String)sessionAttributeService.getSessionAttributes(target.getWebSocketSession()).get("MUD.QUESTION");
+                Map<String, Object> attributes = sessionAttributeService.getSessionAttributes(target.getWebSocketSession());
+                String question = (String)attributes.get("MUD.QUESTION");
                 String action;
+                String flags = "";
+
+                if (attributes.isEmpty()) {
+                    flags += "[dred]([red]LINKDEAD[dred])";
+                }
 
                 if (question != null && question.endsWith("EditorQuestion")) {
-                    action = "busy, altering the threads of time and space";
+                    action = "busy altering the threads of time and space";
                 } else {
                     action = "here";
                 }
 
-                output.append("[green]%s is %s.", target.getName(), action);
+                output.append("[green]%s is %s. %s", target.getName(), action, flags);
             });
 
         repositoryBundle.getItemRepository().getByRoomId(room.getId())

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterMenuQuestion.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterMenuQuestion.java
@@ -74,12 +74,16 @@ public class CharacterMenuQuestion extends BaseQuestion {
         menuPane.getItems().add(new MenuItem("N", "New Character"));
 
         getRepositoryBundle().getCharacterPrototypeRepository().findByUsername(principal.getName())
-            .forEach(ch -> menuPane.getItems().add(new MenuItem(
-                Integer.toString(menuPane.getItems().size()),
-                String.format("%s%s%s",
-                    ch.getId() == 1L ? "[yellow]" : "[white]",
-                    ch.getName(),
-                    ch.getComplete() ? "" : " [dred]*[red]INCOMPLETE[dred]*"),
-                ch.getId())));
+            .forEach(ch -> {
+                boolean playing = getRepositoryBundle().getCharacterRepository().findByName(ch.getName()).isPresent();
+                menuPane.getItems().add(new MenuItem(
+                    Integer.toString(menuPane.getItems().size()),
+                    String.format("%s%s%s%s",
+                        ch.getId() == 1L ? "[yellow]" : "[white]",
+                        ch.getName(),
+                        playing ? " [dgreen]*[green]PLAYING[dgreen]*" : "",
+                        ch.getComplete() ? "" : " [dred]*[red]INCOMPLETE[dred]*"),
+                    ch.getId()));
+            });
     }
 }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterViewQuestion.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterViewQuestion.java
@@ -84,7 +84,9 @@ public class CharacterViewQuestion extends BaseQuestion {
                 MudCharacterPrototype chPrototype = chOptional.get();
 
                 if (!chPrototype.getComplete()) {
-                    output.append("[red]This character is not finished yet. You should character creation first.");
+                    output.append("[red]This character is not finished yet. You must go through character creation first.");
+                } else if (getRepositoryBundle().getCharacterRepository().findByName(chPrototype.getName()).isPresent()) {
+                    output.append("[red]This character is already playing. Try a different one, or create a new one.");
                 } else {
                     MudCharacter ch = chPrototype.buildInstance();
                     MudRoom room = roomOptional.get();

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/repository/MudCharacterRepository.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/repository/MudCharacterRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 @Repository
 public interface MudCharacterRepository extends JpaRepository<MudCharacter, Long> {
+    Optional<MudCharacter> findByName(String name);
     List<MudCharacter> findByUsername(String username);
     List<MudCharacter> findByRoomId(Long roomId);
     List<MudCharacter> findByRoomIdBetween(Long firstRoomId, Long lastRoomId);


### PR DESCRIPTION
Usually when you close your browser your character gets removed from the game, but when the game shuts down while you are still logged in it will leave your character in the game when it comes back up with no way to remove it. This change fixes that so that your old character will get removed after a short time. It also prevents logging the same character in more than once.

* Visibly mark characters who are "link dead", or disconnected but still in the game.
* Clean up link dead characters periodically.
* Don't let characters log into the game more than once at a time.