### PR TITLE
Avoid Code Duplication

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterNameQuestion.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterNameQuestion.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Component;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.agonyforge.mud.core.config.SessionConfiguration.MUD_PCHARACTER;
 
@@ -71,7 +72,7 @@ public class CharacterNameQuestion extends BaseQuestion {
         ch.setName(input.getInput());
         ch.setRoles(Set.of(playerRole));
         ch.setPronoun(Pronoun.THEY);
-        ch.setWearSlots(Arrays.stream(WearSlot.values()).toList());
+        ch.setWearSlots(Arrays.stream(WearSlot.values()).collect(Collectors.toSet()));
 
         ch = getRepositoryBundle().getCharacterPrototypeRepository().save(ch);
         wsContext.getAttributes().put(MUD_PCHARACTER, ch.getId());

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterSheetFormatter.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterSheetFormatter.java
@@ -3,10 +3,7 @@ package com.agonyforge.mud.demo.cli.question.login;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.demo.model.constant.Effort;
 import com.agonyforge.mud.demo.model.constant.Stat;
-import com.agonyforge.mud.demo.model.impl.MudCharacter;
-import com.agonyforge.mud.demo.model.impl.MudCharacterPrototype;
-import com.agonyforge.mud.demo.model.impl.MudProfession;
-import com.agonyforge.mud.demo.model.impl.MudSpecies;
+import com.agonyforge.mud.demo.model.impl.*;
 import com.agonyforge.mud.demo.model.repository.MudProfessionRepository;
 import com.agonyforge.mud.demo.model.repository.MudSpeciesRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,40 +23,13 @@ public final class CharacterSheetFormatter {
         this.professionRepository = professionRepository;
     }
 
-    public void format(MudCharacterPrototype ch, Output output) {
+    public void format(AbstractMudCharacter ch, Output output) {
         // TODO this is only used to get the species name, should denormalize that too maybe?
         MudSpecies species = speciesRepository.findById(ch.getSpeciesId() != null ? ch.getSpeciesId() : DEFAULT_SPECIES_ID).orElseThrow();
         MudProfession profession = professionRepository.findById(ch.getProfessionId() != null ? ch.getProfessionId() : DEFAULT_PROFESSION_ID).orElseThrow();
 
         output.append("[dcyan]CHARACTER SHEET");
         output.append("[default]Name: [%s]%s", ch.getId() == 1L ? "yellow" : "cyan", ch.getName());
-        output.append("[default]Pronouns: [cyan]%s/%s", ch.getPronoun().getSubject(), ch.getPronoun().getObject());
-        output.append("[default]Species: [cyan]%s", species.getName());
-        output.append("[default]Profession: [cyan]%s", profession.getName());
-        output.append("");
-        output.append("[cyan]Stats  [magenta]Efforts");
-        for (int i = 0; i < Math.max(Stat.values().length, Effort.values().length); i++) {
-            Stat stat = Stat.values().length > i ? Stat.values()[i] : null;
-            Effort effort = Effort.values().length > i ? Effort.values()[i] : null;
-
-            String statString = stat != null ? String.format("[default]%s: [cyan]%d", stat.getAbbreviation(), ch.getStat(stat)) : "";
-            String effortString = effort != null ? String.format("[default](d%-2d) %-15s: [magenta]%d", effort.getDie(), effort.getName(), ch.getEffort(effort)) : "";
-
-            output.append("%15s\t%15s", statString, effortString);
-        }
-
-        output.append("");
-        output.append("[default]Health: [red]❤");
-        output.append("[default]DEF: [green]%d", ch.getDefense());
-    }
-
-    public void format(MudCharacter ch, Output output) {
-        // TODO this is only used to get the species name, should denormalize that too maybe?
-        MudSpecies species = speciesRepository.findById(ch.getSpeciesId() != null ? ch.getSpeciesId() : DEFAULT_SPECIES_ID).orElseThrow();
-        MudProfession profession = professionRepository.findById(ch.getProfessionId() != null ? ch.getProfessionId() : DEFAULT_PROFESSION_ID).orElseThrow();
-
-        output.append("[dcyan]CHARACTER SHEET");
-        output.append("[default]Name: [%s]%s", ch.getPrototypeId() == 1L ? "yellow" : "cyan", ch.getName());
         output.append("[default]Pronouns: [cyan]%s/%s", ch.getPronoun().getSubject(), ch.getPronoun().getObject());
         output.append("[default]Species: [cyan]%s", species.getName());
         output.append("[default]Profession: [cyan]%s", profession.getName());

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/AbstractMudCharacter.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/AbstractMudCharacter.java
@@ -1,0 +1,215 @@
+package com.agonyforge.mud.demo.model.impl;
+
+import com.agonyforge.mud.demo.model.constant.Effort;
+import com.agonyforge.mud.demo.model.constant.Pronoun;
+import com.agonyforge.mud.demo.model.constant.Stat;
+import com.agonyforge.mud.demo.model.constant.WearSlot;
+import jakarta.persistence.*;
+
+import java.util.*;
+
+@MappedSuperclass
+public abstract class AbstractMudCharacter extends Persistent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    private String username;
+    private String name;
+    private Pronoun pronoun;
+    private Long speciesId;
+    private Long professionId;
+
+    public AbstractMudCharacter() {
+        Arrays.stream(Stat.values()).forEach((stat) -> stats.put(stat, 0));
+        Arrays.stream(Effort.values()).forEach((effort) -> efforts.put(effort, 0));
+        Arrays.stream(Stat.values()).forEach((stat) -> speciesStats.put(stat, 0));
+        Arrays.stream(Effort.values()).forEach((effort) -> speciesEfforts.put(effort, 0));
+        Arrays.stream(Stat.values()).forEach((stat) -> professionStats.put(stat, 0));
+        Arrays.stream(Effort.values()).forEach((effort) -> professionEfforts.put(effort, 0));
+    }
+
+    @ManyToMany()
+    private Set<Role> roles = new HashSet<>();
+
+    @ElementCollection
+    @CollectionTable(joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
+    private Set<WearSlot> wearSlots = new HashSet<>();
+
+    @ElementCollection
+    @CollectionTable(joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
+    @MapKeyColumn(name = "stat_id")
+    private final Map<Stat, Integer> stats = new HashMap<>();
+
+    @ElementCollection
+    @CollectionTable(joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
+    @MapKeyColumn(name = "effort_id")
+    private final Map<Effort, Integer> efforts = new HashMap<>();
+
+    @ElementCollection
+    @CollectionTable(joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
+    @MapKeyColumn(name = "stat_id")
+    private final Map<Stat, Integer> speciesStats = new HashMap<>();
+
+    @ElementCollection
+    @CollectionTable(joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
+    @MapKeyColumn(name = "effort_id")
+    private final Map<Effort, Integer> speciesEfforts = new HashMap<>();
+
+    @ElementCollection
+    @CollectionTable(joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
+    @MapKeyColumn(name = "stat_id")
+    private final Map<Stat, Integer> professionStats = new HashMap<>();
+
+    @ElementCollection
+    @CollectionTable(joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
+    @MapKeyColumn(name = "effort_id")
+    private final Map<Effort, Integer> professionEfforts = new HashMap<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Pronoun getPronoun() {
+        return pronoun;
+    }
+
+    public void setPronoun(Pronoun pronoun) {
+        this.pronoun = pronoun;
+    }
+
+    public Set<Role> getRoles() {
+        return new HashSet<>(roles);
+    }
+
+    public void setRoles(Set<Role> roles) {
+        this.roles = new HashSet<>(roles);
+    }
+
+    public Set<WearSlot> getWearSlots() {
+        return new HashSet<>(wearSlots);
+    }
+
+    public void setWearSlots(Set<WearSlot> wearSlots) {
+        this.wearSlots = new HashSet<>(wearSlots);
+    }
+
+    public int getStat(Stat stat) {
+        return stats.get(stat) + speciesStats.get(stat) + professionStats.get(stat);
+    }
+
+    public int getBaseStat(Stat stat) {
+        return stats.get(stat);
+    }
+
+    public void setBaseStat(Stat stat, int value) {
+        stats.put(stat, value);
+    }
+
+    public void addBaseStat(Stat stat, int addend) {
+        stats.put(stat, stats.get(stat) + addend);
+    }
+
+    public int getSpeciesStat(Stat stat) {
+        return speciesStats.get(stat);
+    }
+
+    public void setSpeciesStat(Stat stat, int value) {
+        speciesStats.put(stat, value);
+    }
+
+    public void addSpeciesStat(Stat stat, int addend) {
+        speciesStats.put(stat, speciesStats.get(stat) + addend);
+    }
+
+    public int getProfessionStat(Stat stat) {
+        return professionStats.get(stat);
+    }
+
+    public void setProfessionStat(Stat stat, int value) {
+        professionStats.put(stat, value);
+    }
+
+    public void addProfessionStat(Stat stat, int addend) {
+        professionStats.put(stat, professionStats.get(stat) + addend);
+    }
+
+    public int getDefense() {
+        return getBaseStat(Stat.CON) + getSpeciesStat(Stat.CON);
+    }
+
+    public int getEffort(Effort effort) {
+        return efforts.get(effort) + speciesEfforts.get(effort) + professionEfforts.get(effort);
+    }
+
+    public int getBaseEffort(Effort effort) {
+        return efforts.get(effort);
+    }
+
+    public void setBaseEffort(Effort effort, int value) {
+        efforts.put(effort, value);
+    }
+
+    public void addBaseEffort(Effort effort, int addend) {
+        efforts.put(effort, efforts.get(effort) + addend);
+    }
+
+    public int getSpeciesEffort(Effort effort) {
+        return speciesEfforts.get(effort);
+    }
+
+    public void setSpeciesEffort(Effort effort, int value) {
+        speciesEfforts.put(effort, value);
+    }
+
+    public void addSpeciesEffort(Effort effort, int addend) {
+        speciesEfforts.put(effort, speciesEfforts.get(effort) + addend);
+    }
+
+    public int getProfessionEffort(Effort effort) {
+        return professionEfforts.get(effort);
+    }
+
+    public void setProfessionEffort(Effort effort, int value) {
+        professionEfforts.put(effort, value);
+    }
+
+    public void addProfessionEffort(Effort effort, int addend) {
+        professionEfforts.put(effort, professionEfforts.get(effort) + addend);
+    }
+
+    public Long getSpeciesId() {
+        return speciesId;
+    }
+
+    public void setSpeciesId(Long speciesId) {
+        this.speciesId = speciesId;
+    }
+
+    public Long getProfessionId() {
+        return professionId;
+    }
+
+    public void setProfessionId(Long professionId) {
+        this.professionId = professionId;
+    }
+}

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/AbstractMudItem.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/AbstractMudItem.java
@@ -1,0 +1,65 @@
+package com.agonyforge.mud.demo.model.impl;
+
+import com.agonyforge.mud.demo.model.constant.WearSlot;
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+
+@MappedSuperclass
+public abstract class AbstractMudItem extends Persistent {
+    @Transient
+    private List<String> transientNameList = new ArrayList<>();
+
+    @Column(name = "namelist")
+    private String nameList;
+    private String shortDescription;
+    private String longDescription;
+
+    @Convert(converter = WearSlot.Converter.class)
+    private EnumSet<WearSlot> wearSlots = EnumSet.noneOf(WearSlot.class);
+
+    public List<String> getNameList() {
+        if (!transientNameList.isEmpty()) {
+            return new ArrayList<>(transientNameList);
+        }
+
+        return nameList == null ? List.of() : Arrays.stream(nameList.split(",")).toList();
+    }
+
+    public void setNameList(List<String> names) {
+        transientNameList = new ArrayList<>(names);
+        nameList = String.join(",", transientNameList);
+    }
+
+    @PostLoad
+    private void loadNameList() {
+        transientNameList = nameList == null ? List.of() : Arrays.stream(nameList.split(",")).toList();
+    }
+
+    public String getShortDescription() {
+        return shortDescription;
+    }
+
+    public void setShortDescription(String shortDescription) {
+        this.shortDescription = shortDescription;
+    }
+
+    public String getLongDescription() {
+        return longDescription;
+    }
+
+    public void setLongDescription(String longDescription) {
+        this.longDescription = longDescription;
+    }
+
+    public EnumSet<WearSlot> getWearSlots() {
+        return wearSlots;
+    }
+
+    public void setWearSlots(EnumSet<WearSlot> wearSlots) {
+        this.wearSlots = wearSlots;
+    }
+}

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacter.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacter.java
@@ -1,89 +1,17 @@
 package com.agonyforge.mud.demo.model.impl;
 
-import com.agonyforge.mud.demo.model.constant.Effort;
-import com.agonyforge.mud.demo.model.constant.Pronoun;
-import com.agonyforge.mud.demo.model.constant.Stat;
-import com.agonyforge.mud.demo.model.constant.WearSlot;
 import jakarta.persistence.*;
 
 import java.util.*;
 
 @Entity
-@Table(name = "mud_character")
-public class MudCharacter extends Persistent {
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private Long id;
+public class MudCharacter extends AbstractMudCharacter {
     private Long prototypeId;
-    private String username;
     private String webSocketSession;
     private Long roomId;
-    private String name;
-    private Pronoun pronoun;
 
     @ManyToMany
     private Set<Role> roles = new HashSet<>();
-
-    @ElementCollection
-    @CollectionTable(name = "mud_character_wearslot_mapping",
-    joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
-    private List<WearSlot> wearSlots = new ArrayList<>();
-
-    @ElementCollection
-    @CollectionTable(name = "mud_character_stat_mapping",
-    joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
-    @MapKeyColumn(name = "stat_id")
-    private final Map<Stat, Integer> stats = new HashMap<>();
-
-    @ElementCollection
-    @CollectionTable(name = "mud_character_effort_mapping",
-    joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
-    @MapKeyColumn(name = "effort_id")
-    private final Map<Effort, Integer> efforts = new HashMap<>();
-
-    @ElementCollection
-    @CollectionTable(name = "mud_character_speciesstats_mapping",
-    joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
-    @MapKeyColumn(name = "stat_id")
-    private final Map<Stat, Integer> speciesStats = new HashMap<>();
-
-    @ElementCollection
-    @CollectionTable(name = "mud_character_specieseffort_mapping",
-    joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
-    @MapKeyColumn(name = "effort_id")
-    private final Map<Effort, Integer> speciesEfforts = new HashMap<>();
-
-    @ElementCollection
-    @CollectionTable(name = "mud_character_professionstats_mapping",
-    joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
-    @MapKeyColumn(name = "stat_id")
-    private final Map<Stat, Integer> professionStats = new HashMap<>();
-
-    @ElementCollection
-    @CollectionTable(name = "mud_character_professioneffort_mapping",
-    joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
-    @MapKeyColumn(name = "effort_id")
-    private final Map<Effort, Integer> professionEfforts = new HashMap<>();
-
-    private Long speciesId;
-    private Long professionId;
-
-    public MudCharacter() {
-        Arrays.stream(Stat.values()).forEach((stat) -> stats.put(stat, 0));
-        Arrays.stream(Effort.values()).forEach((effort) -> efforts.put(effort, 0));
-        Arrays.stream(Stat.values()).forEach((stat) -> speciesStats.put(stat, 0));
-        Arrays.stream(Effort.values()).forEach((effort) -> speciesEfforts.put(effort, 0));
-        Arrays.stream(Stat.values()).forEach((stat) -> professionStats.put(stat, 0));
-        Arrays.stream(Effort.values()).forEach((effort) -> professionEfforts.put(effort, 0));
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public Long getPrototypeId() {
         return prototypeId;
@@ -91,14 +19,6 @@ public class MudCharacter extends Persistent {
 
     public void setPrototypeId(Long prototypeId) {
         this.prototypeId = prototypeId;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String user) {
-        this.username = user;
     }
 
     public String getWebSocketSession() {
@@ -121,138 +41,6 @@ public class MudCharacter extends Persistent {
 
     public void setRoomId(Long roomId) {
         this.roomId = roomId;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public Pronoun getPronoun() {
-        return pronoun;
-    }
-
-    public void setPronoun(Pronoun pronoun) {
-        this.pronoun = pronoun;
-    }
-
-    public Set<Role> getRoles() {
-        return roles;
-    }
-
-    public void setRoles(Set<Role> roles) {
-        this.roles = roles;
-    }
-
-    public List<WearSlot> getWearSlots() {
-        return new ArrayList<>(wearSlots);
-    }
-
-    public void setWearSlots(List<WearSlot> wearSlots) {
-        this.wearSlots = wearSlots;
-    }
-
-    public int getStat(Stat stat) {
-        return stats.get(stat) + speciesStats.get(stat) + professionStats.get(stat);
-    }
-
-    public int getBaseStat(Stat stat) {
-        return stats.get(stat);
-    }
-
-    public void setBaseStat(Stat stat, int value) {
-        stats.put(stat, value);
-    }
-
-    public void addBaseStat(Stat stat, int addend) {
-        stats.put(stat, stats.get(stat) + addend);
-    }
-
-    public int getSpeciesStat(Stat stat) {
-        return speciesStats.get(stat);
-    }
-
-    public void setSpeciesStat(Stat stat, int value) {
-        speciesStats.put(stat, value);
-    }
-
-    public void addSpeciesStat(Stat stat, int addend) {
-        speciesStats.put(stat, speciesStats.get(stat) + addend);
-    }
-
-    public int getProfessionStat(Stat stat) {
-        return professionStats.get(stat);
-    }
-
-    public void setProfessionStat(Stat stat, int value) {
-        professionStats.put(stat, value);
-    }
-
-    public void addProfessionStat(Stat stat, int addend) {
-        professionStats.put(stat, professionStats.get(stat) + addend);
-    }
-
-    public int getDefense() {
-        return getBaseStat(Stat.CON) + getSpeciesStat(Stat.CON);
-    }
-
-    public int getEffort(Effort effort) {
-        return efforts.get(effort) + speciesEfforts.get(effort) + professionEfforts.get(effort);
-    }
-
-    public int getBaseEffort(Effort effort) {
-        return efforts.get(effort);
-    }
-
-    public void setBaseEffort(Effort effort, int value) {
-        efforts.put(effort, value);
-    }
-
-    public void addBaseEffort(Effort effort, int addend) {
-        efforts.put(effort, efforts.get(effort) + addend);
-    }
-
-    public int getSpeciesEffort(Effort effort) {
-        return speciesEfforts.get(effort);
-    }
-
-    public void setSpeciesEffort(Effort effort, int value) {
-        speciesEfforts.put(effort, value);
-    }
-
-    public void addSpeciesEffort(Effort effort, int addend) {
-        speciesEfforts.put(effort, speciesEfforts.get(effort) + addend);
-    }
-
-    public int getProfessionEffort(Effort effort) {
-        return professionEfforts.get(effort);
-    }
-
-    public void setProfessionEffort(Effort effort, int value) {
-        professionEfforts.put(effort, value);
-    }
-
-    public void addProfessionEffort(Effort effort, int addend) {
-        professionEfforts.put(effort, professionEfforts.get(effort) + addend);
-    }
-
-    public Long getSpeciesId() {
-        return speciesId;
-    }
-
-    public void setSpeciesId(Long speciesId) {
-        this.speciesId = speciesId;
-    }
-
-    public Long getProfessionId() {
-        return professionId;
-    }
-
-    public void setProfessionId(Long professionId) {
-        this.professionId = professionId;
     }
 
     @Override

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacterPrototype.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacterPrototype.java
@@ -1,79 +1,14 @@
 package com.agonyforge.mud.demo.model.impl;
 
 import com.agonyforge.mud.demo.model.constant.Effort;
-import com.agonyforge.mud.demo.model.constant.Pronoun;
 import com.agonyforge.mud.demo.model.constant.Stat;
-import com.agonyforge.mud.demo.model.constant.WearSlot;
 import jakarta.persistence.*;
 
 import java.util.*;
 
 @Entity
-@Table(name = "mud_pcharacter")
-public class MudCharacterPrototype extends Persistent {
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private Long id;
+public class MudCharacterPrototype extends AbstractMudCharacter {
     private Boolean isComplete = false;
-    private String username;
-    private String name;
-    private Pronoun pronoun;
-
-    @ManyToMany()
-    private Set<Role> roles = new HashSet<>();
-
-    @ElementCollection
-    @CollectionTable(name = "mud_pcharacter_wearslot_mapping",
-    joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
-    private List<WearSlot> wearSlots = new ArrayList<>();
-
-    @ElementCollection
-    @CollectionTable(name = "mud_pcharacter_stat_mapping",
-    joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
-    @MapKeyColumn(name = "stat_id")
-    private final Map<Stat, Integer> stats = new HashMap<>();
-
-    @ElementCollection
-    @CollectionTable(name = "mud_pcharacter_effort_mapping",
-    joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
-    @MapKeyColumn(name = "effort_id")
-    private final Map<Effort, Integer> efforts = new HashMap<>();
-
-    @ElementCollection
-    @CollectionTable(name = "mud_pcharacter_speciesstats_mapping",
-    joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
-    @MapKeyColumn(name = "stat_id")
-    private final Map<Stat, Integer> speciesStats = new HashMap<>();
-
-    @ElementCollection
-    @CollectionTable(name = "mud_pcharacter_specieseffort_mapping",
-    joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
-    @MapKeyColumn(name = "effort_id")
-    private final Map<Effort, Integer> speciesEfforts = new HashMap<>();
-
-    @ElementCollection
-    @CollectionTable(name = "mud_pcharacter_professionstats_mapping",
-    joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
-    @MapKeyColumn(name = "stat_id")
-    private final Map<Stat, Integer> professionStats = new HashMap<>();
-
-    @ElementCollection
-    @CollectionTable(name = "mud_pcharacter_professioneffort_mapping",
-    joinColumns = {@JoinColumn(name = "character_id", referencedColumnName = "id")})
-    @MapKeyColumn(name = "effort_id")
-    private final Map<Effort, Integer> professionEfforts = new HashMap<>();
-
-    private Long speciesId;
-    private Long professionId;
-
-    public MudCharacterPrototype() {
-        Arrays.stream(Stat.values()).forEach((stat) -> stats.put(stat, 0));
-        Arrays.stream(Effort.values()).forEach((effort) -> efforts.put(effort, 0));
-        Arrays.stream(Stat.values()).forEach((stat) -> speciesStats.put(stat, 0));
-        Arrays.stream(Effort.values()).forEach((effort) -> speciesEfforts.put(effort, 0));
-        Arrays.stream(Stat.values()).forEach((stat) -> professionStats.put(stat, 0));
-        Arrays.stream(Effort.values()).forEach((effort) -> professionEfforts.put(effort, 0));
-    }
 
     public MudCharacter buildInstance() {
         if (getComplete() == null || !getComplete()) {
@@ -107,160 +42,12 @@ public class MudCharacterPrototype extends Persistent {
         return instance;
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public Boolean getComplete() {
         return isComplete;
     }
 
     public void setComplete(Boolean complete) {
         isComplete = complete;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public Pronoun getPronoun() {
-        return pronoun;
-    }
-
-    public void setPronoun(Pronoun pronoun) {
-        this.pronoun = pronoun;
-    }
-
-    public Set<Role> getRoles() {
-        return new HashSet<>(roles);
-    }
-
-    public void setRoles(Set<Role> roles) {
-        this.roles = new HashSet<>(roles);
-    }
-
-    public List<WearSlot> getWearSlots() {
-        return new ArrayList<>(wearSlots);
-    }
-
-    public void setWearSlots(List<WearSlot> wearSlots) {
-        this.wearSlots = wearSlots;
-    }
-
-    public int getStat(Stat stat) {
-        return stats.get(stat) + speciesStats.get(stat) + professionStats.get(stat);
-    }
-
-    public int getBaseStat(Stat stat) {
-        return stats.get(stat);
-    }
-
-    public void setBaseStat(Stat stat, int value) {
-        stats.put(stat, value);
-    }
-
-    public void addBaseStat(Stat stat, int addend) {
-        stats.put(stat, stats.get(stat) + addend);
-    }
-
-    public int getSpeciesStat(Stat stat) {
-        return speciesStats.get(stat);
-    }
-
-    public void setSpeciesStat(Stat stat, int value) {
-        speciesStats.put(stat, value);
-    }
-
-    public void addSpeciesStat(Stat stat, int addend) {
-        speciesStats.put(stat, speciesStats.get(stat) + addend);
-    }
-
-    public int getProfessionStat(Stat stat) {
-        return professionStats.get(stat);
-    }
-
-    public void setProfessionStat(Stat stat, int value) {
-        professionStats.put(stat, value);
-    }
-
-    public void addProfessionStat(Stat stat, int addend) {
-        professionStats.put(stat, professionStats.get(stat) + addend);
-    }
-
-    public int getDefense() {
-        return getBaseStat(Stat.CON) + getSpeciesStat(Stat.CON);
-    }
-
-    public int getEffort(Effort effort) {
-        return efforts.get(effort) + speciesEfforts.get(effort) + professionEfforts.get(effort);
-    }
-
-    public int getBaseEffort(Effort effort) {
-        return efforts.get(effort);
-    }
-
-    public void setBaseEffort(Effort effort, int value) {
-        efforts.put(effort, value);
-    }
-
-    public void addBaseEffort(Effort effort, int addend) {
-        efforts.put(effort, efforts.get(effort) + addend);
-    }
-
-    public int getSpeciesEffort(Effort effort) {
-        return speciesEfforts.get(effort);
-    }
-
-    public void setSpeciesEffort(Effort effort, int value) {
-        speciesEfforts.put(effort, value);
-    }
-
-    public void addSpeciesEffort(Effort effort, int addend) {
-        speciesEfforts.put(effort, speciesEfforts.get(effort) + addend);
-    }
-
-    public int getProfessionEffort(Effort effort) {
-        return professionEfforts.get(effort);
-    }
-
-    public void setProfessionEffort(Effort effort, int value) {
-        professionEfforts.put(effort, value);
-    }
-
-    public void addProfessionEffort(Effort effort, int addend) {
-        professionEfforts.put(effort, professionEfforts.get(effort) + addend);
-    }
-
-    public Long getSpeciesId() {
-        return speciesId;
-    }
-
-    public void setSpeciesId(Long speciesId) {
-        this.speciesId = speciesId;
-    }
-
-    public Long getProfessionId() {
-        return professionId;
-    }
-
-    public void setProfessionId(Long professionId) {
-        this.professionId = professionId;
     }
 
     @Override

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudItem.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudItem.java
@@ -2,32 +2,19 @@ package com.agonyforge.mud.demo.model.impl;
 
 import com.agonyforge.mud.demo.model.constant.WearSlot;
 import jakarta.persistence.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
 @Entity
 @Table(name = "mud_item")
-public class MudItem extends Persistent {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MudItem.class);
-
+public class MudItem extends AbstractMudItem {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "instance_id")
-    private Long instanceId = null;
+    private Long instanceId;
     private Long id;
     private Long roomId;
     private Long chId;
-
-    @Transient
-    private List<String> transientNameList = new ArrayList<>();
-    private String nameList;
-    private String shortDescription;
-    private String longDescription;
-
-    @Convert(converter = WearSlot.Converter.class)
-    private EnumSet<WearSlot> wearSlots = EnumSet.noneOf(WearSlot.class);
 
     private WearSlot worn;
 
@@ -71,48 +58,6 @@ public class MudItem extends Persistent {
         this.roomId = roomId;
     }
 
-    public List<String> getNameList() {
-        if (!transientNameList.isEmpty()) {
-            return new ArrayList<>(transientNameList);
-        }
-
-        return nameList == null ? List.of() : Arrays.stream(nameList.split(",")).toList();
-    }
-
-    public void setNameList(List<String> names) {
-        transientNameList = new ArrayList<>(names);
-        nameList = String.join(",", transientNameList);
-    }
-
-    @PostLoad
-    private void loadNameList() {
-        transientNameList = nameList == null ? List.of() : Arrays.stream(nameList.split(",")).toList();
-    }
-
-    public String getShortDescription() {
-        return shortDescription;
-    }
-
-    public void setShortDescription(String shortDescription) {
-        this.shortDescription = shortDescription;
-    }
-
-    public String getLongDescription() {
-        return longDescription;
-    }
-
-    public void setLongDescription(String longDescription) {
-        this.longDescription = longDescription;
-    }
-
-    public EnumSet<WearSlot> getWearSlots() {
-        return wearSlots;
-    }
-
-    public void setWearSlots(EnumSet<WearSlot> wearSlots) {
-        this.wearSlots = wearSlots;
-    }
-
     public WearSlot getWorn() {
         return worn;
     }
@@ -125,11 +70,11 @@ public class MudItem extends Persistent {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof MudItem mudItem)) return false;
-        return Objects.equals(getId(), mudItem.getId());
+        return Objects.equals(getInstanceId(), mudItem.getInstanceId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId());
+        return Objects.hash(getInstanceId());
     }
 }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudItemPrototype.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudItemPrototype.java
@@ -1,28 +1,14 @@
 package com.agonyforge.mud.demo.model.impl;
 
-import com.agonyforge.mud.demo.model.constant.WearSlot;
 import jakarta.persistence.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
 @Entity
 @Table(name = "mud_pitem")
-public class MudItemPrototype extends Persistent {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MudItemPrototype.class);
-
+public class MudItemPrototype extends AbstractMudItem {
     @Id
     private Long id;
-
-    @Transient
-    private List<String> transientNameList = new ArrayList<>();
-    private String nameList;
-    private String shortDescription;
-    private String longDescription;
-
-    @Convert(converter = WearSlot.Converter.class)
-    private EnumSet<WearSlot> wearSlots = EnumSet.noneOf(WearSlot.class);
 
     public MudItem buildInstance() {
         MudItem instance = new MudItem();
@@ -42,48 +28,6 @@ public class MudItemPrototype extends Persistent {
 
     public void setId(Long id) {
         this.id = id;
-    }
-
-    public List<String> getNameList() {
-        if (!transientNameList.isEmpty()) {
-            return new ArrayList<>(transientNameList);
-        }
-
-        return nameList == null ? List.of() : Arrays.stream(nameList.split(",")).toList();
-    }
-
-    public void setNameList(List<String> names) {
-        transientNameList = new ArrayList<>(names);
-        nameList = String.join(",", transientNameList);
-    }
-
-    @PostLoad
-    private void loadNameList() {
-        transientNameList = nameList == null ? List.of() : Arrays.stream(nameList.split(",")).toList();
-    }
-
-    public String getShortDescription() {
-        return shortDescription;
-    }
-
-    public void setShortDescription(String shortDescription) {
-        this.shortDescription = shortDescription;
-    }
-
-    public String getLongDescription() {
-        return longDescription;
-    }
-
-    public void setLongDescription(String longDescription) {
-        this.longDescription = longDescription;
-    }
-
-    public EnumSet<WearSlot> getWearSlots() {
-        return wearSlots;
-    }
-
-    public void setWearSlots(EnumSet<WearSlot> wearSlots) {
-        this.wearSlots = wearSlots;
     }
 
     @Override

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/WearCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/WearCommandTest.java
@@ -204,7 +204,7 @@ public class WearCommandTest {
             MUD_CHARACTER, chId
         ));
         when(itemRepository.getByChId(ch.getId())).thenReturn(List.of(target));
-        when(ch.getWearSlots()).thenReturn(List.of(WearSlot.HEAD));
+        when(ch.getWearSlots()).thenReturn(Set.of(WearSlot.HEAD));
         when(ch.getPronoun()).thenReturn(Pronoun.SHE);
         when(target.getShortDescription()).thenReturn("a test hat");
         when(target.getNameList()).thenReturn(List.of("hat"));
@@ -239,7 +239,7 @@ public class WearCommandTest {
             MUD_CHARACTER, chId
         ));
         when(itemRepository.getByChId(ch.getId())).thenReturn(List.of(item, target));
-        when(ch.getWearSlots()).thenReturn(List.of(WearSlot.HELD_LEFT, WearSlot.HELD_RIGHT, WearSlot.HEAD));
+        when(ch.getWearSlots()).thenReturn(Set.of(WearSlot.HELD_LEFT, WearSlot.HELD_RIGHT, WearSlot.HEAD));
         when(ch.getPronoun()).thenReturn(Pronoun.SHE);
         when(item.getWorn()).thenReturn(WearSlot.HELD_LEFT);
         when(target.getShortDescription()).thenReturn("a test hat");
@@ -275,7 +275,7 @@ public class WearCommandTest {
             MUD_CHARACTER, chId
         ));
         when(itemRepository.getByChId(ch.getId())).thenReturn(List.of(item, target));
-        when(ch.getWearSlots()).thenReturn(List.of(WearSlot.HELD_LEFT, WearSlot.HELD_RIGHT, WearSlot.HEAD));
+        when(ch.getWearSlots()).thenReturn(Set.of(WearSlot.HELD_LEFT, WearSlot.HELD_RIGHT, WearSlot.HEAD));
         when(ch.getPronoun()).thenReturn(Pronoun.SHE);
         when(item.getWorn()).thenReturn(WearSlot.HELD_LEFT);
         when(target.getShortDescription()).thenReturn("a test hat");

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/model/impl/MudCharacterPrototypeTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/model/impl/MudCharacterPrototypeTest.java
@@ -8,11 +8,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 public class MudCharacterPrototypeTest {
@@ -106,9 +107,9 @@ public class MudCharacterPrototypeTest {
     void testWearSlots() {
         MudCharacterPrototype uut = new MudCharacterPrototype();
 
-        uut.setWearSlots(List.of(WearSlot.HEAD));
+        uut.setWearSlots(Set.of(WearSlot.HEAD));
 
-        assertEquals(WearSlot.HEAD, uut.getWearSlots().get(0));
+        assertTrue(uut.getWearSlots().contains(WearSlot.HEAD));
     }
 
     @Test

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/model/impl/MudCharacterTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/model/impl/MudCharacterTest.java
@@ -8,11 +8,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 public class MudCharacterTest {
@@ -103,9 +104,9 @@ public class MudCharacterTest {
     void testWearSlots() {
         MudCharacter uut = new MudCharacter();
 
-        uut.setWearSlots(List.of(WearSlot.HEAD));
+        uut.setWearSlots(Set.of(WearSlot.HEAD));
 
-        assertEquals(WearSlot.HEAD, uut.getWearSlots().get(0));
+        assertTrue(uut.getWearSlots().contains(WearSlot.HEAD));
     }
 
     @Test


### PR DESCRIPTION
Refactored characters and items to avoid a large amount of duplicated code.  Unfortunately this also resulted in the renaming of many of the database columns, which was unavoidable.

This is the first step toward NPCs, because now I can simply make them extend `AbstractMudCharacter` and get all the stats, wearslots, and a whole new set of tables for it all exactly the same as the other two classes for free instead of copy/pasting it all a third time.