### PR TITLE
rename wear slots for held items

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/constant/WearSlot.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/constant/WearSlot.java
@@ -21,8 +21,8 @@ public enum WearSlot implements PersistentEnum {
     FACE("face", "worn on face"),
     ANKLE_LEFT("left ankle", "worn on left ankle"),
     ANKLE_RIGHT("right ankle", "worn on right ankle"),
-    HELD_LEFT("left hand", "held in left hand"),
-    HELD_RIGHT("right hand", "held in right hand");
+    HELD_OFF("off hand", "held in off hand"),
+    HELD_WEAPON("weapon hand", "held in weapon hand");
 
     private final String name;
     private final String phrase;

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/WearCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/WearCommandTest.java
@@ -281,15 +281,15 @@ public class WearCommandTest {
         when(room.getId()).thenReturn(100L);
         when(ch.getLocation()).thenReturn(chLocationComponent);
         when(ch.getLocation().getRoom()).thenReturn(room);
-        when(ch.getCharacter().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_LEFT, WearSlot.HELD_RIGHT, WearSlot.HEAD));
+        when(ch.getCharacter().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_OFF, WearSlot.HELD_WEAPON, WearSlot.HEAD));
         when(ch.getCharacter().getPronoun()).thenReturn(Pronoun.SHE);
         when(item.getLocation()).thenReturn(itemLocationComponent);
-        when(item.getLocation().getWorn()).thenReturn(WearSlot.HELD_LEFT);
+        when(item.getLocation().getWorn()).thenReturn(WearSlot.HELD_OFF);
         when(target.getItem()).thenReturn(targetItemComponent);
         when(target.getLocation()).thenReturn(targetLocationComponent);
         when(target.getItem().getShortDescription()).thenReturn("a test hat");
         when(target.getItem().getNameList()).thenReturn(Set.of("hat"));
-        when(target.getItem().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_LEFT, WearSlot.HEAD));
+        when(target.getItem().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_OFF, WearSlot.HEAD));
 
         Output output = new Output();
         WearCommand uut = new WearCommand(repositoryBundle, commService, applicationContext);
@@ -324,10 +324,10 @@ public class WearCommandTest {
         when(room.getId()).thenReturn(100L);
         when(ch.getLocation()).thenReturn(chLocationComponent);
         when(ch.getLocation().getRoom()).thenReturn(room);
-        when(ch.getCharacter().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_LEFT, WearSlot.HELD_RIGHT, WearSlot.HEAD));
+        when(ch.getCharacter().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_OFF, WearSlot.HELD_WEAPON, WearSlot.HEAD));
         when(ch.getCharacter().getPronoun()).thenReturn(Pronoun.SHE);
         when(item.getLocation()).thenReturn(itemLocationComponent);
-        when(item.getLocation().getWorn()).thenReturn(WearSlot.HELD_LEFT);
+        when(item.getLocation().getWorn()).thenReturn(WearSlot.HELD_OFF);
         when(target.getItem()).thenReturn(targetItemComponent);
         when(target.getLocation()).thenReturn(targetLocationComponent);
         when(target.getItem().getShortDescription()).thenReturn("a test hat");


### PR DESCRIPTION
Switch from right and left to 'weapon' and 'off' so we don't need to assume handedness.