### PR TITLE
items can have multiple wear slots and occupy all of them

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/AbstractCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/AbstractCommand.java
@@ -66,7 +66,7 @@ public abstract class AbstractCommand implements Command {
 
         return items
             .stream()
-            .filter(item -> item.getLocation().getWorn() == null)
+            .filter(item -> item.getLocation().getWorn() == null || item.getLocation().getWorn().isEmpty())
             .filter(item -> item.getItem().getNameList()
                 .stream()
                 .anyMatch(name -> name.toUpperCase(Locale.ROOT).startsWith(token.toUpperCase(Locale.ROOT))))
@@ -78,7 +78,7 @@ public abstract class AbstractCommand implements Command {
 
         return items
             .stream()
-            .filter(item -> item.getLocation().getWorn() != null)
+            .filter(item -> item.getLocation().getWorn() != null && !item.getLocation().getWorn().isEmpty())
             .filter(item -> item.getItem().getNameList()
                 .stream()
                 .anyMatch(name -> name.toUpperCase(Locale.ROOT).startsWith(token.toUpperCase(Locale.ROOT))))

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/CreateCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/CreateCommand.java
@@ -5,6 +5,7 @@ import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.WearSlot;
 import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import com.agonyforge.mud.demo.model.impl.MudItem;
 import com.agonyforge.mud.demo.model.impl.MudItemTemplate;
@@ -13,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -47,7 +49,7 @@ public class CreateCommand extends AbstractCommand {
         }
 
         MudItem item = itemProto.get().buildInstance();
-        item.getLocation().setWorn(null);
+        item.getLocation().setWorn(EnumSet.noneOf(WearSlot.class));
         item.getLocation().setHeld(ch);
         item.getLocation().setRoom(null);
         item = getRepositoryBundle().getItemRepository().save(item);

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/DropCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/DropCommand.java
@@ -5,6 +5,7 @@ import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.WearSlot;
 import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import com.agonyforge.mud.demo.model.impl.MudItem;
 import com.agonyforge.mud.demo.service.CommService;
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -40,12 +42,12 @@ public class DropCommand extends AbstractCommand {
 
         MudItem target = targetOptional.get();
 
-        if (target.getLocation().getWorn() != null) {
+        if (!target.getLocation().getWorn().isEmpty()) {
             output.append("[default]You need to remove it first.");
             return question;
         }
 
-        target.getLocation().setWorn(null);
+        target.getLocation().setWorn(EnumSet.noneOf(WearSlot.class));
         target.getLocation().setHeld(null);
         target.getLocation().setRoom(ch.getLocation().getRoom());
         getRepositoryBundle().getItemRepository().save(target);

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/EquipmentCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/EquipmentCommand.java
@@ -9,6 +9,7 @@ import com.agonyforge.mud.demo.model.constant.WearSlot;
 import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import com.agonyforge.mud.demo.model.impl.MudItem;
 import com.agonyforge.mud.demo.service.CommService;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
@@ -31,8 +32,9 @@ public class EquipmentCommand extends AbstractCommand {
         MudCharacter ch = getCurrentCharacter(webSocketContext, output);
         Map<WearSlot, MudItem> inventory = getRepositoryBundle().getItemRepository().findByLocationHeld(ch)
                 .stream()
-                .filter(item -> item.getLocation() != null && item.getLocation().getWorn() != null)
-                .collect(Collectors.toMap((item) -> item.getLocation().getWorn(), Function.identity()));
+                .filter(item -> item.getLocation() != null && !item.getLocation().getWorn().isEmpty())
+                .flatMap(item -> item.getLocation().getWorn().stream().map(slot -> new ImmutablePair<>(slot, item)))
+                .collect(Collectors.toMap(ImmutablePair::getLeft, ImmutablePair::getRight));
 
         output.append("[default]You are using:");
 

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/GetCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/GetCommand.java
@@ -5,6 +5,7 @@ import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.WearSlot;
 import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import com.agonyforge.mud.demo.model.impl.MudItem;
 import com.agonyforge.mud.demo.service.CommService;
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -39,7 +41,7 @@ public class GetCommand extends AbstractCommand {
         }
 
         MudItem target = targetOptional.get();
-        target.getLocation().setWorn(null);
+        target.getLocation().setWorn(EnumSet.noneOf(WearSlot.class));
         target.getLocation().setHeld(ch);
         target.getLocation().setRoom(null);
         getRepositoryBundle().getItemRepository().save(target);

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/GiveCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/GiveCommand.java
@@ -5,6 +5,7 @@ import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.WearSlot;
 import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import com.agonyforge.mud.demo.model.impl.MudItem;
 import com.agonyforge.mud.demo.service.CommService;
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -52,13 +54,13 @@ public class GiveCommand extends AbstractCommand {
         MudItem item = itemOptional.get();
         MudCharacter target = targetOptional.get();
 
-        if (item.getLocation().getWorn() != null) {
+        if (!item.getLocation().getWorn().isEmpty()) {
             LOGGER.error("Worn item was found in inventory! id:{} proto:{}", item.getTemplate().getId(), item.getId());
             output.append("[default]You need to remove it first.");
             return question;
         }
 
-        item.getLocation().setWorn(null);
+        item.getLocation().setWorn(EnumSet.noneOf(WearSlot.class));
         item.getLocation().setHeld(target);
         item.getLocation().setRoom(null);
         getRepositoryBundle().getItemRepository().save(item);

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/InventoryCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/InventoryCommand.java
@@ -32,7 +32,7 @@ public class InventoryCommand extends AbstractCommand {
 
         List<MudItem> held = items
             .stream()
-            .filter(item -> item.getLocation().getWorn() == null).toList();
+            .filter(item -> item.getLocation().getWorn().isEmpty()).toList();
 
         if (held.isEmpty()) {
             output.append("[default]Nothing.");

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/ItemEditorCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/ItemEditorCommand.java
@@ -5,6 +5,7 @@ import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.impl.ItemComponent;
 import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import com.agonyforge.mud.demo.model.impl.MudItem;
 import com.agonyforge.mud.demo.model.impl.MudItemTemplate;
@@ -55,6 +56,7 @@ public class ItemEditorCommand extends AbstractCommand {
                 MudItemTemplate itemPrototype = new MudItemTemplate();
 
                 itemPrototype.setId(id);
+                itemPrototype.setItem(new ItemComponent());
 
                 itemProto = Optional.of(getRepositoryBundle().getItemPrototypeRepository().save(itemPrototype));
             } catch (NumberFormatException e) {

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/RemoveCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/RemoveCommand.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -41,13 +42,14 @@ public class RemoveCommand extends AbstractCommand {
 
         MudItem target = targetOptional.get();
 
-        if (target.getLocation().getWorn() == null) {
+        if (target.getLocation().getWorn().isEmpty()) {
             output.append("[default]You aren't wearing %s[default].", target.getItem().getShortDescription());
             return question;
         }
 
-        WearSlot targetSlot = target.getLocation().getWorn();
-        target.getLocation().setWorn(null);
+        String slotNames = String.join(", ", target.getLocation().getWorn().stream().map(WearSlot::getName).toList());
+
+        target.getLocation().setWorn(EnumSet.noneOf(WearSlot.class));
         target.getLocation().setHeld(ch);
         target.getLocation().setRoom(null);
         getRepositoryBundle().getItemRepository().save(target);
@@ -58,7 +60,7 @@ public class RemoveCommand extends AbstractCommand {
                 ch.getCharacter().getName(),
                 target.getItem().getShortDescription(),
                 ch.getCharacter().getPronoun().getPossessive(),
-                targetSlot.getName()
+                slotNames
             ));
 
         return question;

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/LocationComponent.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/LocationComponent.java
@@ -3,6 +3,7 @@ package com.agonyforge.mud.demo.model.impl;
 import com.agonyforge.mud.demo.model.constant.WearSlot;
 import jakarta.persistence.*;
 
+import java.util.EnumSet;
 import java.util.Objects;
 
 @Entity
@@ -14,7 +15,8 @@ public class LocationComponent extends Persistent {
     @ManyToOne
     private MudCharacter held = null;
 
-    private WearSlot worn = null;
+    @Convert(converter = WearSlot.Converter.class)
+    private EnumSet<WearSlot> worn = null;
 
     @ManyToOne
     private MudRoom room = null;
@@ -35,11 +37,11 @@ public class LocationComponent extends Persistent {
         this.held = heldBy;
     }
 
-    public WearSlot getWorn() {
+    public EnumSet<WearSlot> getWorn() {
         return worn;
     }
 
-    public void setWorn(WearSlot wornOn) {
+    public void setWorn(EnumSet<WearSlot> wornOn) {
         this.worn = wornOn;
     }
 

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/util/BaseEnumSetConverter.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/util/BaseEnumSetConverter.java
@@ -17,6 +17,10 @@ public abstract class BaseEnumSetConverter <E extends Enum<E> & PersistentEnum> 
     public Long convertToDatabaseColumn(EnumSet<E> attribute) {
         long total = 0;
 
+        if (attribute == null) {
+            return total;
+        }
+
         for (E constant : attribute) {
             total |= 1L << constant.ordinal();
         }

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/DropCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/DropCommandTest.java
@@ -5,6 +5,7 @@ import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.WearSlot;
 import com.agonyforge.mud.demo.model.impl.*;
 import com.agonyforge.mud.demo.model.repository.MudCharacterRepository;
 import com.agonyforge.mud.demo.model.repository.MudItemRepository;
@@ -157,6 +158,7 @@ public class DropCommandTest {
         ));
         when(room.getId()).thenReturn(100L);
         when(item.getLocation()).thenReturn(locationComponent);
+        when(item.getLocation().getWorn()).thenReturn(EnumSet.noneOf(WearSlot.class));
         when(item.getItem()).thenReturn(itemComponent);
         when(item.getItem().getNameList()).thenReturn(Set.of("test"));
         when(item.getItem().getShortDescription()).thenReturn(itemName);
@@ -177,7 +179,7 @@ public class DropCommandTest {
         verify(itemRepository).findByLocationHeld(eq(ch));
         verify(locationComponent).setHeld(eq(null));
         verify(locationComponent).setRoom(eq(room));
-        verify(locationComponent).setWorn(eq(null));
+        verify(locationComponent).setWorn(eq(EnumSet.noneOf(WearSlot.class)));
         verify(itemRepository).save(eq(item));
         verify(itemRepository, never()).save(eq(other));
         verify(commService).sendToRoom(eq(webSocketContext), eq(100L), any(Output.class));

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/EquipmentCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/EquipmentCommandTest.java
@@ -117,7 +117,7 @@ public class EquipmentCommandTest {
         ));
         when(itemRepository.findByLocationHeld(eq(ch))).thenReturn(List.of(junk, item));
         when(item.getLocation()).thenReturn(itemLocationComponent);
-        when(item.getLocation().getWorn()).thenReturn(WearSlot.HEAD);
+        when(item.getLocation().getWorn()).thenReturn(EnumSet.of(WearSlot.HEAD));
         when(item.getItem()).thenReturn(itemComponent);
         when(item.getItem().getShortDescription()).thenReturn("a rubber chicken");
 

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/GetCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/GetCommandTest.java
@@ -5,6 +5,7 @@ import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.WearSlot;
 import com.agonyforge.mud.demo.model.impl.*;
 import com.agonyforge.mud.demo.model.repository.MudCharacterRepository;
 import com.agonyforge.mud.demo.model.repository.MudItemRepository;
@@ -176,7 +177,7 @@ public class GetCommandTest {
         verify(itemRepository).findByLocationRoom(eq(room));
         verify(itemLocationComponent).setHeld(eq(ch));
         verify(itemLocationComponent).setRoom(eq(null));
-        verify(itemLocationComponent).setWorn(eq(null));
+        verify(itemLocationComponent).setWorn(eq(EnumSet.noneOf(WearSlot.class)));
         verify(itemRepository).save(eq(item));
         verify(itemRepository, never()).save(eq(other));
         verify(commService).sendToRoom(eq(webSocketContext), eq(roomId), any(Output.class));

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/GiveCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/GiveCommandTest.java
@@ -5,6 +5,7 @@ import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.WearSlot;
 import com.agonyforge.mud.demo.model.impl.*;
 import com.agonyforge.mud.demo.model.repository.MudCharacterRepository;
 import com.agonyforge.mud.demo.model.repository.MudItemRepository;
@@ -226,6 +227,7 @@ public class GiveCommandTest {
             MUD_CHARACTER, chId
         ));
         when(item.getLocation()).thenReturn(itemLocationComponent);
+        when(item.getLocation().getWorn()).thenReturn(EnumSet.noneOf(WearSlot.class));
         when(item.getItem()).thenReturn(itemComponent);
         when(item.getItem().getNameList()).thenReturn(Set.of("spoon"));
         when(item.getItem().getShortDescription()).thenReturn("a spoon");
@@ -246,7 +248,7 @@ public class GiveCommandTest {
         verify(itemRepository).findByLocationHeld(eq(ch));
         verify(characterRepository).findByLocationRoom(eq(room));
         verify(itemLocationComponent).setHeld(eq(target));
-        verify(itemLocationComponent).setWorn(eq(null));
+        verify(itemLocationComponent).setWorn(eq(EnumSet.noneOf(WearSlot.class)));
         verify(itemLocationComponent).setRoom(eq(null));
         verify(itemRepository).save(eq(item));
         verify(commService).sendTo(eq(target), any(Output.class));

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/InventoryCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/InventoryCommandTest.java
@@ -98,10 +98,11 @@ public class InventoryCommandTest {
         when(itemProto.getId()).thenReturn(102L);
         when(item.getTemplate()).thenReturn(itemProto);
         when(item.getLocation()).thenReturn(itemLocationComponent);
+        when(item.getLocation().getWorn()).thenReturn(EnumSet.noneOf(WearSlot.class));
         when(item.getItem()).thenReturn(itemComponent);
         when(item.getItem().getShortDescription()).thenReturn(itemName);
         when(armor.getLocation()).thenReturn(armorLocationComponent);
-        when(armor.getLocation().getWorn()).thenReturn(WearSlot.BODY);
+        when(armor.getLocation().getWorn()).thenReturn(EnumSet.of(WearSlot.BODY));
         when(itemRepository.findByLocationHeld(eq(ch))).thenReturn(List.of(armor, item));
 
         Output output = new Output();

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/RemoveCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/RemoveCommandTest.java
@@ -150,7 +150,7 @@ public class RemoveCommandTest {
         when(target.getItem().getNameList()).thenReturn(Set.of("test", "hat"));
         when(target.getItem().getShortDescription()).thenReturn("a test hat");
         when(target.getLocation()).thenReturn(targetLocationComponent);
-        when(target.getLocation().getWorn()).thenReturn(WearSlot.HEAD);
+        when(target.getLocation().getWorn()).thenReturn(EnumSet.of(WearSlot.HEAD));
 
         Output output = new Output();
         RemoveCommand uut = new RemoveCommand(repositoryBundle, commService, applicationContext);
@@ -163,7 +163,7 @@ public class RemoveCommandTest {
 
         verify(targetLocationComponent).setHeld(eq(ch));
         verify(targetLocationComponent).setRoom(eq(null));
-        verify(targetLocationComponent).setWorn(eq(null));
+        verify(targetLocationComponent).setWorn(eq(EnumSet.noneOf(WearSlot.class)));
         verify(itemRepository).save(any(MudItem.class));
         verify(commService).sendToRoom(
             eq(webSocketContext),


### PR DESCRIPTION
First of a two part change. Items can have multiple wear slots enabled. This PR makes it so that an item takes up all the wear slots that it has enabled. So if a polearm has both hands enabled, it takes both hands to wear it.