### PR TITLE
Dual WearSlot Modes

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/WorldLoader.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/WorldLoader.java
@@ -94,7 +94,7 @@ public class WorldLoader {
     }
 
     private void loadItems() {
-        if (itemRepository.findById(100L).isEmpty()) {
+        if (itemPrototypeRepository.findById(100L).isEmpty()) {
             MudRoom room100 = roomRepository.findById(100L).orElseThrow();
             MudRoom room101 = roomRepository.findById(101L).orElseThrow();
 

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/event/CharacterJanitor.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/event/CharacterJanitor.java
@@ -57,7 +57,7 @@ public class CharacterJanitor implements ApplicationListener<SessionDisconnectEv
                 // TODO copy relevant differences in instance back to prototype
                 characterRepository.delete(instance);
 
-                LOGGER.info("{} has left the game.", instance.getCharacter().getName());
+                LOGGER.info("{} has left the game", instance.getCharacter().getName());
 
                 WebSocketContext webSocketContext = WebSocketContext.build(event.getMessage().getHeaders());
                 commService.sendToAll(webSocketContext,
@@ -87,7 +87,7 @@ public class CharacterJanitor implements ApplicationListener<SessionDisconnectEv
             // TODO copy relevant differences in instance back to prototype
             characterRepository.delete(ch);
 
-            LOGGER.info("{} has left the game.", ch.getCharacter().getName());
+            LOGGER.info("{} has left the game", ch.getCharacter().getName());
             commService.sendToAll(new Output("[yellow]%s has left the game!", ch.getCharacter().getName()), ch);
         });
     }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/constant/WearMode.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/constant/WearMode.java
@@ -1,0 +1,9 @@
+package com.agonyforge.mud.demo.model.constant;
+
+/**
+ * Determines how many slots an item takes when you wear it.
+ */
+public enum WearMode {
+    ALL, // item uses all the slots it has enabled
+    SINGLE // item only uses a single slot, but it can be any of the enabled ones
+}

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/constant/WearSlot.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/constant/WearSlot.java
@@ -22,7 +22,7 @@ public enum WearSlot implements PersistentEnum {
     ANKLE_LEFT("left ankle", "worn on left ankle"),
     ANKLE_RIGHT("right ankle", "worn on right ankle"),
     HELD_OFF("off hand", "held in off hand"),
-    HELD_WEAPON("weapon hand", "held in weapon hand");
+    HELD_MAIN("main hand", "held in main hand");
 
     private final String name;
     private final String phrase;

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/ItemComponent.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/ItemComponent.java
@@ -1,5 +1,6 @@
 package com.agonyforge.mud.demo.model.impl;
 
+import com.agonyforge.mud.demo.model.constant.WearMode;
 import com.agonyforge.mud.demo.model.constant.WearSlot;
 import jakarta.persistence.*;
 
@@ -23,6 +24,7 @@ public class ItemComponent extends Persistent {
 
     @Convert(converter = WearSlot.Converter.class)
     private EnumSet<WearSlot> wearSlots = EnumSet.noneOf(WearSlot.class);
+    private WearMode wearMode = WearMode.ALL;
 
     public Long getId() {
         return id;
@@ -62,6 +64,14 @@ public class ItemComponent extends Persistent {
 
     public void setWearSlots(EnumSet<WearSlot> wearSlots) {
         this.wearSlots = wearSlots;
+    }
+
+    public WearMode getWearMode() {
+        return wearMode;
+    }
+
+    public void setWearMode(WearMode wearMode) {
+        this.wearMode = wearMode;
     }
 
     @Override

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudItemTemplate.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudItemTemplate.java
@@ -19,6 +19,7 @@ public class MudItemTemplate extends AbstractMudObject {
         instance.getItem().setShortDescription(getItem().getShortDescription());
         instance.getItem().setLongDescription(getItem().getLongDescription());
         instance.getItem().setWearSlots(getItem().getWearSlots());
+        instance.getItem().setWearMode(getItem().getWearMode());
 
         return instance;
     }

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/CreateCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/CreateCommandTest.java
@@ -1,0 +1,153 @@
+package com.agonyforge.mud.demo.cli.command;
+
+import com.agonyforge.mud.core.cli.Question;
+import com.agonyforge.mud.core.web.model.Input;
+import com.agonyforge.mud.core.web.model.Output;
+import com.agonyforge.mud.core.web.model.WebSocketContext;
+import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.Pronoun;
+import com.agonyforge.mud.demo.model.constant.WearSlot;
+import com.agonyforge.mud.demo.model.impl.*;
+import com.agonyforge.mud.demo.model.repository.MudCharacterRepository;
+import com.agonyforge.mud.demo.model.repository.MudItemPrototypeRepository;
+import com.agonyforge.mud.demo.model.repository.MudItemRepository;
+import com.agonyforge.mud.demo.service.CommService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.agonyforge.mud.core.config.SessionConfiguration.MUD_CHARACTER;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CreateCommandTest {
+    @Mock
+    private ApplicationContext applicationContext;
+
+    @Mock
+    private CommService commService;
+
+    @Mock
+    private RepositoryBundle repositoryBundle;
+
+    @Mock
+    private MudCharacterRepository characterRepository;
+
+    @Mock
+    private MudCharacter ch;
+
+    @Mock
+    private LocationComponent chLocationComponent, itemLocationComponent;
+
+    @Mock
+    private CharacterComponent characterComponent;
+
+    @Mock
+    private ItemComponent itemComponent;
+
+    @Mock
+    private MudItemPrototypeRepository itemPrototypeRepository;
+
+    @Mock
+    private MudItemTemplate itemTemplate;
+
+    @Mock
+    private MudItemRepository itemRepository;
+
+    @Mock
+    private MudItem item;
+
+    @Mock
+    private MudRoom room;
+
+    @Mock
+    private WebSocketContext wsContext;
+
+    @Mock
+    private Question question;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(repositoryBundle.getItemPrototypeRepository()).thenReturn(itemPrototypeRepository);
+
+        lenient().when(repositoryBundle.getCharacterRepository()).thenReturn(characterRepository);
+        lenient().when(repositoryBundle.getItemRepository()).thenReturn(itemRepository);
+    }
+
+    @Test
+    void testNoArgs() {
+        when(wsContext.getAttributes()).thenReturn(Map.of(MUD_CHARACTER, 1L));
+        when(characterRepository.findById(eq(1L))).thenReturn(Optional.of(ch));
+        when(ch.getLocation()).thenReturn(chLocationComponent);
+        when(ch.getLocation().getRoom()).thenReturn(room);
+
+        Output output = new Output();
+        CreateCommand uut = new CreateCommand(repositoryBundle, commService, applicationContext);
+
+        Question response = uut.execute(question, wsContext, List.of("CRE"), new Input("cre"), output);
+
+        assertEquals(question, response);
+
+        verifyNoInteractions(itemRepository);
+        verifyNoInteractions(commService);
+    }
+
+    @Test
+    void testCreateInvalidItem() {
+        when(wsContext.getAttributes()).thenReturn(Map.of(MUD_CHARACTER, 1L));
+        when(characterRepository.findById(eq(1L))).thenReturn(Optional.of(ch));
+        when(ch.getLocation()).thenReturn(chLocationComponent);
+        when(ch.getLocation().getRoom()).thenReturn(room);
+
+        Output output = new Output();
+        CreateCommand uut = new CreateCommand(repositoryBundle, commService, applicationContext);
+
+        Question response = uut.execute(question, wsContext, List.of("CRE", "404"), new Input("cre 404"), output);
+
+        assertEquals(question, response);
+
+        verify(itemPrototypeRepository).findById(eq(404L));
+        verifyNoMoreInteractions(itemPrototypeRepository);
+        verifyNoInteractions(itemRepository);
+        verifyNoInteractions(commService);
+    }
+
+    @Test
+    void testCreateItem() {
+        when(wsContext.getAttributes()).thenReturn(Map.of(MUD_CHARACTER, 1L));
+        when(characterRepository.findById(eq(1L))).thenReturn(Optional.of(ch));
+        when(itemPrototypeRepository.findById(eq(200L))).thenReturn(Optional.of(itemTemplate));
+        when(itemRepository.save(eq(item))).thenReturn(item);
+        when(itemTemplate.buildInstance()).thenReturn(item);
+        when(item.getItem()).thenReturn(itemComponent);
+        when(item.getLocation()).thenReturn(itemLocationComponent);
+        when(ch.getCharacter()).thenReturn(characterComponent);
+        when(ch.getCharacter().getPronoun()).thenReturn(Pronoun.SHE);
+        when(ch.getLocation()).thenReturn(chLocationComponent);
+        when(ch.getLocation().getRoom()).thenReturn(room);
+
+        Output output = new Output();
+        CreateCommand uut = new CreateCommand(repositoryBundle, commService, applicationContext);
+
+        Question response = uut.execute(question, wsContext, List.of("CRE", "200"), new Input("cre 200"), output);
+
+        assertEquals(question, response);
+
+        verify(itemPrototypeRepository).findById(eq(200L));
+        verify(itemLocationComponent).setWorn(eq(EnumSet.noneOf(WearSlot.class)));
+        verify(itemLocationComponent).setHeld(eq(ch));
+        verify(itemLocationComponent).setRoom(eq(null));
+        verify(itemRepository).save(eq(item));
+        verify(commService).sendToRoom(eq(wsContext), anyLong(), any(Output.class));
+    }
+}

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/PurgeCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/PurgeCommandTest.java
@@ -1,0 +1,164 @@
+package com.agonyforge.mud.demo.cli.command;
+
+import com.agonyforge.mud.core.cli.Question;
+import com.agonyforge.mud.core.web.model.Input;
+import com.agonyforge.mud.core.web.model.Output;
+import com.agonyforge.mud.core.web.model.WebSocketContext;
+import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.Pronoun;
+import com.agonyforge.mud.demo.model.impl.*;
+import com.agonyforge.mud.demo.model.repository.MudCharacterRepository;
+import com.agonyforge.mud.demo.model.repository.MudItemRepository;
+import com.agonyforge.mud.demo.service.CommService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.agonyforge.mud.core.config.SessionConfiguration.MUD_CHARACTER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PurgeCommandTest {
+    @Mock
+    private RepositoryBundle repositoryBundle;
+
+    @Mock
+    private MudCharacterRepository characterRepository;
+
+    @Mock
+    private MudItemRepository itemRepository;
+
+    @Mock
+    private CommService commService;
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    @Mock
+    private WebSocketContext wsContext;
+
+    @Mock
+    private Question question;
+
+    @Mock
+    private MudCharacter ch;
+
+    @Mock
+    private MudItem item;
+
+    @Mock
+    private MudRoom room;
+
+    @Mock
+    private LocationComponent chLocationComponent, itemLocationComponent;
+
+    @Mock
+    private ItemComponent itemComponent;
+
+    @Mock
+    private CharacterComponent characterComponent;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(repositoryBundle.getCharacterRepository()).thenReturn(characterRepository);
+        lenient().when(repositoryBundle.getItemRepository()).thenReturn(itemRepository);
+
+        when(wsContext.getAttributes()).thenReturn(Map.of(MUD_CHARACTER, 1L));
+        when(characterRepository.findById(eq(1L))).thenReturn(Optional.of(ch));
+        when(ch.getLocation()).thenReturn(chLocationComponent);
+        when(ch.getLocation().getRoom()).thenReturn(room);
+        when(ch.getCharacter()).thenReturn(characterComponent);
+        lenient().when(ch.getCharacter().getPronoun()).thenReturn(Pronoun.SHE);
+    }
+
+    @Test
+    void testNoArgs() {
+        Output output = new Output();
+        PurgeCommand uut = new PurgeCommand(repositoryBundle, commService, applicationContext);
+
+        Question result = uut.execute(question, wsContext, List.of("PUR"), new Input("pur"), output);
+
+        assertEquals(question, result);
+
+        verifyNoInteractions(itemRepository);
+        verifyNoInteractions(commService);
+    }
+
+    @Test
+    void testNoTarget() {
+        when(itemRepository.findByLocationRoom(eq(room))).thenReturn(List.of());
+
+        Output output = new Output();
+        PurgeCommand uut = new PurgeCommand(repositoryBundle, commService, applicationContext);
+
+        Question result = uut.execute(question, wsContext, List.of("PUR", "TEST"), new Input("pur test"), output);
+
+        assertEquals(question, result);
+
+        verify(itemRepository, never()).delete(eq(item));
+        verifyNoInteractions(commService);
+    }
+
+    @Test
+    void testNoTargetWithMatchingName() {
+        when(itemRepository.findByLocationHeld(eq(ch))).thenReturn(List.of(item));
+        when(item.getLocation()).thenReturn(itemLocationComponent);
+        when(item.getItem()).thenReturn(itemComponent);
+        when(item.getItem().getNameList()).thenReturn(Set.of("dont", "purge", "me", "bro"));
+
+        Output output = new Output();
+        PurgeCommand uut = new PurgeCommand(repositoryBundle, commService, applicationContext);
+
+        Question result = uut.execute(question, wsContext, List.of("PUR", "TEST"), new Input("pur test"), output);
+
+        assertEquals(question, result);
+
+        verify(itemRepository, never()).delete(eq(item));
+        verifyNoInteractions(commService);
+    }
+
+    @Test
+    void testPurgeInventoryItem() {
+        when(itemRepository.findByLocationHeld(eq(ch))).thenReturn(List.of(item));
+        when(item.getLocation()).thenReturn(itemLocationComponent);
+        when(item.getItem()).thenReturn(itemComponent);
+        when(item.getItem().getNameList()).thenReturn(Set.of("test"));
+
+        Output output = new Output();
+        PurgeCommand uut = new PurgeCommand(repositoryBundle, commService, applicationContext);
+
+        Question result = uut.execute(question, wsContext, List.of("PUR", "TEST"), new Input("pur test"), output);
+
+        assertEquals(question, result);
+
+        verify(itemRepository).delete(eq(item));
+        verify(commService).sendToRoom(eq(wsContext), anyLong(), any(Output.class));
+    }
+
+    @Test
+    void testPurgeRoomItem() {
+        when(itemRepository.findByLocationRoom(eq(room))).thenReturn(List.of(item));
+        when(item.getItem()).thenReturn(itemComponent);
+        when(item.getItem().getNameList()).thenReturn(Set.of("test"));
+
+        Output output = new Output();
+        PurgeCommand uut = new PurgeCommand(repositoryBundle, commService, applicationContext);
+
+        Question result = uut.execute(question, wsContext, List.of("PUR", "TEST"), new Input("pur test"), output);
+
+        assertEquals(question, result);
+
+        verify(itemRepository).delete(eq(item));
+        verify(commService).sendToRoom(eq(wsContext), anyLong(), any(Output.class));
+    }
+}

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/WearCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/WearCommandTest.java
@@ -5,6 +5,7 @@ import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.WearMode;
 import com.agonyforge.mud.demo.model.constant.WearSlot;
 import com.agonyforge.mud.demo.model.impl.*;
 import com.agonyforge.mud.demo.model.constant.Pronoun;
@@ -86,6 +87,8 @@ public class WearCommandTest {
         lenient().when(repositoryBundle.getCharacterRepository()).thenReturn(characterRepository);
         lenient().when(repositoryBundle.getItemRepository()).thenReturn(itemRepository);
         lenient().when(repositoryBundle.getRoomRepository()).thenReturn(roomRepository);
+        lenient().when(itemItemComponent.getWearMode()).thenReturn(WearMode.ALL);
+        lenient().when(targetItemComponent.getWearMode()).thenReturn(WearMode.ALL);
     }
 
     @Test
@@ -207,8 +210,8 @@ public class WearCommandTest {
         ));
         when(itemRepository.findByLocationHeld(ch)).thenReturn(List.of(item, target));
 
-        when(item.getItem()).thenReturn(itemItemComponent);
-        when(item.getItem().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HEAD));
+//        when(item.getItem()).thenReturn(itemItemComponent);
+//        when(item.getItem().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HEAD));
         when(item.getLocation()).thenReturn(itemLocationComponent);
         when(item.getLocation().getWorn()).thenReturn(EnumSet.of(WearSlot.HEAD));
 
@@ -290,11 +293,11 @@ public class WearCommandTest {
 
         when(ch.getLocation()).thenReturn(chLocationComponent);
         when(ch.getLocation().getRoom()).thenReturn(room);
-        when(ch.getCharacter().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_OFF, WearSlot.HELD_WEAPON, WearSlot.HEAD));
+        when(ch.getCharacter().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_OFF, WearSlot.HELD_MAIN, WearSlot.HEAD));
         when(ch.getCharacter().getPronoun()).thenReturn(Pronoun.SHE);
 
-        when(item.getItem()).thenReturn(itemItemComponent);
-        when(item.getItem().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_OFF));
+//        when(item.getItem()).thenReturn(itemItemComponent);
+//        when(item.getItem().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_OFF));
         when(item.getLocation()).thenReturn(itemLocationComponent);
         when(item.getLocation().getWorn()).thenReturn(EnumSet.of(WearSlot.HELD_OFF));
 
@@ -339,11 +342,11 @@ public class WearCommandTest {
 
         when(ch.getLocation()).thenReturn(chLocationComponent);
         when(ch.getLocation().getRoom()).thenReturn(room);
-        when(ch.getCharacter().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_OFF, WearSlot.HELD_WEAPON, WearSlot.HEAD));
+        when(ch.getCharacter().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_OFF, WearSlot.HELD_MAIN, WearSlot.HEAD));
         when(ch.getCharacter().getPronoun()).thenReturn(Pronoun.SHE);
 
-        when(item.getItem()).thenReturn(itemItemComponent);
-        when(item.getItem().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_OFF));
+//        when(item.getItem()).thenReturn(itemItemComponent);
+//        when(item.getItem().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_OFF));
         when(item.getLocation()).thenReturn(itemLocationComponent);
         when(item.getLocation().getWorn()).thenReturn(EnumSet.of(WearSlot.HELD_OFF));
 

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/WearCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/WearCommandTest.java
@@ -210,8 +210,6 @@ public class WearCommandTest {
         ));
         when(itemRepository.findByLocationHeld(ch)).thenReturn(List.of(item, target));
 
-//        when(item.getItem()).thenReturn(itemItemComponent);
-//        when(item.getItem().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HEAD));
         when(item.getLocation()).thenReturn(itemLocationComponent);
         when(item.getLocation().getWorn()).thenReturn(EnumSet.of(WearSlot.HEAD));
 
@@ -296,8 +294,6 @@ public class WearCommandTest {
         when(ch.getCharacter().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_OFF, WearSlot.HELD_MAIN, WearSlot.HEAD));
         when(ch.getCharacter().getPronoun()).thenReturn(Pronoun.SHE);
 
-//        when(item.getItem()).thenReturn(itemItemComponent);
-//        when(item.getItem().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_OFF));
         when(item.getLocation()).thenReturn(itemLocationComponent);
         when(item.getLocation().getWorn()).thenReturn(EnumSet.of(WearSlot.HELD_OFF));
 
@@ -345,8 +341,6 @@ public class WearCommandTest {
         when(ch.getCharacter().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_OFF, WearSlot.HELD_MAIN, WearSlot.HEAD));
         when(ch.getCharacter().getPronoun()).thenReturn(Pronoun.SHE);
 
-//        when(item.getItem()).thenReturn(itemItemComponent);
-//        when(item.getItem().getWearSlots()).thenReturn(EnumSet.of(WearSlot.HELD_OFF));
         when(item.getLocation()).thenReturn(itemLocationComponent);
         when(item.getLocation().getWorn()).thenReturn(EnumSet.of(WearSlot.HELD_OFF));
 

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/ingame/olc/item/ItemWearSlotsEditorQuestionTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/ingame/olc/item/ItemWearSlotsEditorQuestionTest.java
@@ -69,11 +69,12 @@ public class ItemWearSlotsEditorQuestionTest {
         ItemWearSlotsEditorQuestion uut = new ItemWearSlotsEditorQuestion(applicationContext, repositoryBundle);
         Output result = uut.prompt(wsContext);
 
-        assertEquals(26, result.getOutput().size());
         assertTrue(result.getOutput().stream().anyMatch(line -> line.contains("Item Wear Slots")));
         assertTrue(result.getOutput().stream().anyMatch(line -> line.contains("make your selection")));
         assertTrue(result.getOutput().stream().anyMatch(line -> line.contains("false")));
         assertTrue(result.getOutput().stream().noneMatch(line -> line.contains("true")));
+        assertTrue(result.getOutput().stream().anyMatch(line -> line.contains("Wear Slot Mode")));
+        assertTrue(result.getOutput().stream().anyMatch(line -> line.contains("Exit")));
     }
 
     @Test
@@ -96,7 +97,6 @@ public class ItemWearSlotsEditorQuestionTest {
         ItemWearSlotsEditorQuestion uut = new ItemWearSlotsEditorQuestion(applicationContext, repositoryBundle);
         Output result = uut.prompt(wsContext);
 
-        assertEquals(26, result.getOutput().size());
         assertTrue(slots.contains(eyes));
         assertTrue(result.getOutput().stream().anyMatch(line -> line.contains("true")));
     }
@@ -121,7 +121,6 @@ public class ItemWearSlotsEditorQuestionTest {
         ItemWearSlotsEditorQuestion uut = new ItemWearSlotsEditorQuestion(applicationContext, repositoryBundle);
         Output result = uut.prompt(wsContext);
 
-        assertEquals(26, result.getOutput().size());
         assertFalse(slots.contains(eyes));
         assertTrue(result.getOutput().stream().noneMatch(line -> line.contains("true")));
     }

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/model/impl/ItemComponentTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/model/impl/ItemComponentTest.java
@@ -1,0 +1,55 @@
+package com.agonyforge.mud.demo.model.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class ItemComponentTest {
+    private static final Random RANDOM = new Random();
+
+    @Test
+    void testId() {
+        Long id = RANDOM.nextLong();
+        ItemComponent uut = new ItemComponent();
+
+        uut.setId(id);
+
+        assertEquals(id, uut.getId());
+    }
+
+    @Test
+    void testNameList() {
+        Set<String> nameList = Set.of("able", "baker", "charlie");
+        ItemComponent uut = new ItemComponent();
+
+        uut.setNameList(nameList);
+
+        assertEquals(nameList, uut.getNameList());
+    }
+
+    @Test
+    void testShortDescription() {
+        String shortDescription = "a wild test";
+        ItemComponent uut = new ItemComponent();
+
+        uut.setShortDescription(shortDescription);
+
+        assertEquals(shortDescription, uut.getShortDescription());
+    }
+
+    @Test
+    void testLongDescription() {
+        String longDescription = "A wild test is zipping around the room.";
+        ItemComponent uut = new ItemComponent();
+
+        uut.setLongDescription(longDescription);
+
+        assertEquals(longDescription, uut.getLongDescription());
+    }
+}

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/model/impl/RoleTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/model/impl/RoleTest.java
@@ -1,0 +1,49 @@
+package com.agonyforge.mud.demo.model.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class RoleTest {
+    private static final Random RANDOM = new Random();
+
+    @Mock
+    private CommandReference commandA, commandB, commandC;
+
+    @Test
+    void testId() {
+        Long id = RANDOM.nextLong();
+        Role uut = new Role();
+
+        uut.setId(id);
+
+        assertEquals(id, uut.getId());
+    }
+
+    @Test
+    void testName() {
+        String name = "Tester";
+        Role uut = new Role();
+
+        uut.setName(name);
+
+        assertEquals(name, uut.getName());
+    }
+
+    @Test
+    void testCommands() {
+        Set<CommandReference> commands = Set.of(commandA, commandB, commandC);
+        Role uut = new Role();
+
+        uut.setCommands(commands);
+
+        assertEquals(commands, uut.getCommands());
+    }
+}


### PR DESCRIPTION
WearSlots now work in two different modes to support different kinds of objects. Any item can have multiple WearSlots enabled. For large, bulky items (polearms, two-handed swords, etc.) you can use `WearMode.ALL` where one item occupies all of the enabled slots. Small or versatile items (earrings, bracelets, etc.) can use `WearMode.SINGLE` so that each item will only occupy one of the selected slots. That way you could wear two different earrings or wield a dagger in each hand.