### PR TITLE
just remove offline characters from the world, don't delete them

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/AbstractCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/AbstractCommand.java
@@ -111,6 +111,7 @@ public abstract class AbstractCommand implements Command {
 
         return targets
             .stream()
+            .filter(tch -> tch.getLocation() != null)
             .filter(tch -> !tch.equals(ch))
             .filter(tch -> tch.getCharacter().getName().toUpperCase(Locale.ROOT).startsWith(token.toUpperCase(Locale.ROOT)))
             .findFirst();

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/WhoCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/WhoCommand.java
@@ -24,6 +24,7 @@ public class WhoCommand extends AbstractCommand {
     public Question execute(Question question, WebSocketContext webSocketContext, List<String> tokens, Input input, Output output) {
         List<MudCharacter> characters = getRepositoryBundle().getCharacterRepository().findAll()
             .stream()
+            .filter(ch -> ch.getLocation() != null)
             .toList();
 
         output

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterMenuQuestion.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/login/CharacterMenuQuestion.java
@@ -12,6 +12,7 @@ import com.agonyforge.mud.core.cli.menu.impl.MenuPane;
 import com.agonyforge.mud.core.cli.menu.impl.MenuPrompt;
 import com.agonyforge.mud.core.cli.menu.impl.MenuTitle;
 import com.agonyforge.mud.demo.cli.question.BaseQuestion;
+import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
@@ -75,7 +76,14 @@ public class CharacterMenuQuestion extends BaseQuestion {
 
         getRepositoryBundle().getCharacterPrototypeRepository().findByPlayerUsername(principal.getName())
             .forEach(ch -> {
-                boolean playing = getRepositoryBundle().getCharacterRepository().findByCharacterName(ch.getCharacter().getName()).isPresent();
+                Optional<MudCharacter> instanceOpt = getRepositoryBundle().getCharacterRepository().findByCharacterName(ch.getCharacter().getName());
+                boolean playing = false;
+
+                if (instanceOpt.isPresent()) {
+                    MudCharacter instance = instanceOpt.get();
+                    playing = instance.getLocation() != null;
+                }
+
                 menuPane.getItems().add(new MenuItem(
                     Integer.toString(menuPane.getItems().size()),
                     String.format("%s%s%s%s",

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/AbstractMudObject.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/AbstractMudObject.java
@@ -15,7 +15,7 @@ public abstract class AbstractMudObject extends Persistent {
     @OneToOne(cascade = CascadeType.ALL)
     private ItemComponent item = null;
 
-    @OneToOne(cascade = CascadeType.ALL)
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     private LocationComponent location = null;
 
     public PlayerComponent getPlayer() {

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/AbstractCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/AbstractCommandTest.java
@@ -62,10 +62,10 @@ public class AbstractCommandTest {
     private MudCharacter target;
 
     @Mock
-    private CharacterComponent targetCharacterComponent;
+    private CharacterComponent chCharacterComponent, targetCharacterComponent;
 
     @Mock
-    private LocationComponent chLocationComponent;
+    private LocationComponent chLocationComponent, targetLocationComponent;
 
     @Mock
     private MudRoom room;
@@ -185,8 +185,8 @@ public class AbstractCommandTest {
 
     @Test
     void testFindWorldCharacter() {
-        when(targetCharacterComponent.getName()).thenReturn("Morgan");
         when(target.getCharacter()).thenReturn(targetCharacterComponent);
+        when(target.getLocation()).thenReturn(targetLocationComponent);
         when(target.getCharacter().getName()).thenReturn("Morgan");
         when(characterRepository.findAll()).thenReturn(List.of(ch, target));
 

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/TellCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/TellCommandTest.java
@@ -71,7 +71,7 @@ public class TellCommandTest {
     private CharacterComponent chCharacterComponent, targetCharacterComponent;
 
     @Mock
-    private LocationComponent chLocationComponent;
+    private LocationComponent chLocationComponent, targetLocationComponent;
 
     @Mock
     private WebSocketContext webSocketContext;
@@ -117,6 +117,7 @@ public class TellCommandTest {
         when(ch.getCharacter()).thenReturn(chCharacterComponent);
         when(ch.getLocation()).thenReturn(chLocationComponent);
         when(ch.getLocation().getRoom()).thenReturn(room);
+        when(target.getLocation()).thenReturn(targetLocationComponent);
         when(target.getCharacter()).thenReturn(targetCharacterComponent);
         when(chCharacterComponent.getName()).thenReturn("Scion");
         when(targetCharacterComponent.getName()).thenReturn("Target");

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/WhoCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/WhoCommandTest.java
@@ -6,6 +6,7 @@ import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
 import com.agonyforge.mud.demo.model.impl.CharacterComponent;
+import com.agonyforge.mud.demo.model.impl.LocationComponent;
 import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import com.agonyforge.mud.demo.model.impl.MudCharacterTemplate;
 import com.agonyforge.mud.demo.model.repository.MudCharacterRepository;
@@ -59,6 +60,9 @@ public class WhoCommandTest {
     private CharacterComponent chCharacterComponent, otherCharacterComponent;
 
     @Mock
+    private LocationComponent chLocationComponent, otherLocationComponent;
+
+    @Mock
     private Question question;
 
     @Mock
@@ -79,6 +83,7 @@ public class WhoCommandTest {
         when(chCharacterComponent.getName()).thenReturn("Scion");
         when(ch.getTemplate()).thenReturn(chProto);
         when(ch.getCharacter()).thenReturn(chCharacterComponent);
+        when(ch.getLocation()).thenReturn(chLocationComponent);
         when(characterRepository.findAll()).thenReturn(characters);
 
         WhoCommand uut = new WhoCommand(repositoryBundle, commService, applicationContext);
@@ -100,8 +105,10 @@ public class WhoCommandTest {
         when(otherCharacterComponent.getName()).thenReturn("Spook");
         when(ch.getTemplate()).thenReturn(chProto);
         when(ch.getCharacter()).thenReturn(chCharacterComponent);
+        when(ch.getLocation()).thenReturn(chLocationComponent);
         when(other.getTemplate()).thenReturn(oProto);
         when(other.getCharacter()).thenReturn(otherCharacterComponent);
+        when(other.getLocation()).thenReturn(otherLocationComponent);
         when(characterRepository.findAll()).thenReturn(characters);
 
         WhoCommand uut = new WhoCommand(repositoryBundle, commService, applicationContext);

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/event/CharacterJanitorTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/event/CharacterJanitorTest.java
@@ -5,6 +5,7 @@ import com.agonyforge.mud.core.service.timer.TimerEvent;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.model.impl.CharacterComponent;
+import com.agonyforge.mud.demo.model.impl.LocationComponent;
 import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import com.agonyforge.mud.demo.model.impl.PlayerComponent;
 import com.agonyforge.mud.demo.model.repository.MudCharacterRepository;
@@ -54,6 +55,9 @@ public class CharacterJanitorTest {
     private CharacterComponent chChComponent, otherChComponent;
 
     @Mock
+    private LocationComponent chLocationComponent, otherLocationComponent;
+
+    @Mock
     private MudCharacter ch;
 
     @Mock
@@ -86,7 +90,7 @@ public class CharacterJanitorTest {
 
             uut.onApplicationEvent(event);
 
-            verify(characterRepository).delete(ch);
+            verify(characterRepository).save(ch);
             verify(commService).sendToAll(any(WebSocketContext.class), any(Output.class), eq(ch));
         }
     }
@@ -98,16 +102,18 @@ public class CharacterJanitorTest {
         when(timerEvent.getFrequency()).thenReturn(TimeUnit.MINUTES);
         when(ch.getPlayer()).thenReturn(chPlayer);
         when(ch.getCharacter()).thenReturn(chChComponent);
+        when(ch.getLocation()).thenReturn(chLocationComponent);
         when(chPlayer.getWebSocketSession()).thenReturn("abc");
         when(other.getPlayer()).thenReturn(otherPlayer);
         when(other.getCharacter()).thenReturn(otherChComponent);
+        when(other.getLocation()).thenReturn(otherLocationComponent);
         when(otherPlayer.getWebSocketSession()).thenReturn("def");
         when(characterRepository.findAll()).thenReturn(List.of(ch, other));
 
         uut.onTimerEvent(timerEvent);
 
         verify(sessionAttributeService, times(2)).getSessionAttributes(anyString());
-        verify(characterRepository, times(2)).delete(any(MudCharacter.class));
+        verify(characterRepository, times(2)).save(any(MudCharacter.class));
         verify(commService, times(2)).sendToAll(any(Output.class), any(MudCharacter.class));
     }
 }


### PR DESCRIPTION
Fixes #391 

When you create a new character, you're creating a `MudCharacterTemplate`. The first time you play the character it builds a `MudCharacter` from the template and places it into the world. Until now, when you leave the game it would delete your `MudCharacter` from the world. If you were carrying or wearing any items it would throw an exception and fail to delete you because the deletion didn't cascade to the items.

I've been wrestling with a couple of related issues:
* How to remove offline players from the game without it throwing exceptions?
* How to make it remember the items the player had?
* How to make it save changes to the `MudCharacter` back to the `MudCharacterTemplate`?

This PR is honestly a hack but it solves all of these problems. We simply don't delete the `MudCharacter` at all anymore. We just take off its `LocationComponent`, effectively removing it from the world, and make sure it doesn't show up anywhere while it's offline. When you come back we check for it being there and use it if it is, or create a new one if it isn't. This way the items also stay, and they stay associated with your character. Bringing you back into the game is as simple as attaching a new `LocationComponent` to place you back in the world. Poof!

In the future I will most likely skip making a `MudCharacterTemplate` for players entirely and reserve that for NPCs.