### PR TITLE
Fix redit edit bugs

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/RoomEditorCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/RoomEditorCommand.java
@@ -60,7 +60,7 @@ public class RoomEditorCommand extends AbstractCommand {
                     room = roomOptional.get();
                 }
 
-                webSocketContext.getAttributes().put(REDIT_MODEL, room);
+                webSocketContext.getAttributes().put(REDIT_MODEL, room.getId());
             } catch (NumberFormatException e) {
                 LOGGER.error(e.getMessage());
                 output
@@ -72,7 +72,7 @@ public class RoomEditorCommand extends AbstractCommand {
             }
         } else {
             room = ch.getLocation().getRoom();
-            webSocketContext.getAttributes().put(REDIT_MODEL, room);
+            webSocketContext.getAttributes().put(REDIT_MODEL, room.getId());
         }
 
         getCommService().sendToRoom(ch.getLocation().getRoom().getId(),

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomEditorQuestion.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomEditorQuestion.java
@@ -112,11 +112,11 @@ public class RoomEditorQuestion extends BaseQuestion {
 
     private MudRoom getRoomModel(WebSocketContext wsContext, MudCharacter ch) {
         if (!wsContext.getAttributes().containsKey(REDIT_MODEL)) {
-            MudRoom room = getRepositoryBundle().getRoomRepository().findById(ch.getLocation().getRoom().getId()).orElseThrow();
-            wsContext.getAttributes().put(REDIT_MODEL, room);
+            wsContext.getAttributes().put(REDIT_MODEL, ch.getLocation().getRoom().getId());
         }
 
-        return (MudRoom)wsContext.getAttributes().get(REDIT_MODEL);
+        Long roomId = (Long)wsContext.getAttributes().get(REDIT_MODEL);
+        return getRepositoryBundle().getRoomRepository().findById(roomId).orElseThrow();
     }
 
     private void populateMenuItems(MudRoom room) {

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomEditorQuestion.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomEditorQuestion.java
@@ -38,7 +38,6 @@ public class RoomEditorQuestion extends BaseQuestion {
     private static final Logger LOGGER = LoggerFactory.getLogger(RoomEditorQuestion.class);
 
     private final CommService commService;
-
     private final MenuPane menuPane = new MenuPane();
 
     @Autowired

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomExitsEditorQuestion.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomExitsEditorQuestion.java
@@ -13,7 +13,6 @@ import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
 import com.agonyforge.mud.demo.cli.question.BaseQuestion;
 import com.agonyforge.mud.demo.model.constant.Direction;
-import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import com.agonyforge.mud.demo.model.impl.MudRoom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,8 +48,7 @@ public class RoomExitsEditorQuestion extends BaseQuestion {
     @Override
     public Output prompt(WebSocketContext wsContext) {
         Output output = new Output();
-        MudCharacter ch = getCharacter(wsContext, output).orElseThrow();
-        MudRoom room = getRoomModel(wsContext, ch);
+        MudRoom room = getRepositoryBundle().getRoomRepository().findById((Long)wsContext.getAttributes().get(REDIT_MODEL)).orElseThrow();
 
         if (wsContext.getAttributes().containsKey(REDIT_STATE) && wsContext.getAttributes().get(REDIT_STATE).toString().startsWith("ROOM.EXITS")) {
             output.append("Destination room ID for exit %s, or 0 to delete: ", wsContext.getAttributes().get(REDIT_EXIT));
@@ -65,8 +63,7 @@ public class RoomExitsEditorQuestion extends BaseQuestion {
     public Response answer(WebSocketContext wsContext, Input input) {
         String nextQuestion = "roomExitsEditorQuestion";
         Output output = new Output();
-        MudCharacter ch = getCharacter(wsContext, output).orElseThrow();
-        MudRoom room = getRoomModel(wsContext, ch);
+        MudRoom room = getRepositoryBundle().getRoomRepository().findById((Long)wsContext.getAttributes().get(REDIT_MODEL)).orElseThrow();
 
         if (wsContext.getAttributes().containsKey(REDIT_EXIT)) {
             try {
@@ -120,17 +117,6 @@ public class RoomExitsEditorQuestion extends BaseQuestion {
         Question next = getQuestion(nextQuestion);
 
         return new Response(next, output);
-    }
-
-    private MudRoom getRoomModel(WebSocketContext wsContext, MudCharacter ch) {
-        if (!wsContext.getAttributes().containsKey(REDIT_MODEL)) {
-            LOGGER.error("{} doesn't have a room model.", this.getClass().getSimpleName());
-
-            MudRoom room = getRepositoryBundle().getRoomRepository().findById(ch.getLocation().getRoom().getId()).orElseThrow();
-            wsContext.getAttributes().put(REDIT_MODEL, room);
-        }
-
-        return (MudRoom)wsContext.getAttributes().get(REDIT_MODEL);
     }
 
     void populateMenuItems(MudRoom room) {

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomExitsEditorQuestion.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomExitsEditorQuestion.java
@@ -124,10 +124,13 @@ public class RoomExitsEditorQuestion extends BaseQuestion {
 
     private MudRoom getRoomModel(WebSocketContext wsContext, MudCharacter ch) {
         if (!wsContext.getAttributes().containsKey(REDIT_MODEL)) {
-            wsContext.getAttributes().put(REDIT_MODEL, ch.getLocation().getRoom().getId());
+            LOGGER.error("{} doesn't have a room model.", this.getClass().getSimpleName());
+
+            MudRoom room = getRepositoryBundle().getRoomRepository().findById(ch.getLocation().getRoom().getId()).orElseThrow();
+            wsContext.getAttributes().put(REDIT_MODEL, room);
         }
 
-        return ch.getLocation().getRoom();
+        return (MudRoom)wsContext.getAttributes().get(REDIT_MODEL);
     }
 
     void populateMenuItems(MudRoom room) {

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomFlagsEditorQuestion.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomFlagsEditorQuestion.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
+import static com.agonyforge.mud.demo.cli.question.ingame.olc.room.RoomEditorQuestion.REDIT_MODEL;
 import static com.agonyforge.mud.demo.cli.question.ingame.olc.room.RoomEditorQuestion.REDIT_STATE;
 
 @Component
@@ -39,7 +40,7 @@ public class RoomFlagsEditorQuestion extends BaseQuestion {
 
     @Override
     public Output prompt(WebSocketContext wsContext) {
-        MudRoom room = (MudRoom)wsContext.getAttributes().get("REDIT.MODEL");
+        MudRoom room = getRepositoryBundle().getRoomRepository().findById((Long)wsContext.getAttributes().get(REDIT_MODEL)).orElseThrow();
 
         if (wsContext.getAttributes().containsKey(REDIT_STATE)) {
             if (wsContext.getAttributes().get(REDIT_STATE).toString().equals(REDIT_FLAG)) {

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/RoomEditorCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/RoomEditorCommandTest.java
@@ -95,7 +95,7 @@ public class RoomEditorCommandTest {
         when(applicationContext.getBean(eq("roomEditorQuestion"), eq(Question.class))).thenReturn(reditQuestion);
         when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
         when(wsContext.getAttributes()).thenReturn(attributes);
-        when(room.getId()).thenReturn(100L);
+        when(room.getId()).thenReturn(roomId);
         when(ch.getLocation()).thenReturn(chLocationComponent);
         when(ch.getCharacter()).thenReturn(characterComponent);
         when(ch.getLocation().getRoom()).thenReturn(room);
@@ -105,7 +105,7 @@ public class RoomEditorCommandTest {
 
         Question result = uut.execute(originalQuestion, wsContext, List.of("REDIT"), new Input("redit"), output);
 
-        assertEquals(room, attributes.get(REDIT_MODEL));
+        assertEquals(roomId, attributes.get(REDIT_MODEL));
         assertEquals(reditQuestion, result);
     }
 
@@ -124,13 +124,14 @@ public class RoomEditorCommandTest {
         when(ch.getLocation()).thenReturn(chLocationComponent);
         when(ch.getLocation().getRoom()).thenReturn(room);
         when(roomRepository.findById(eq(roomId))).thenReturn(Optional.of(room));
+        when(room.getId()).thenReturn(roomId);
 
         RoomEditorCommand uut = new RoomEditorCommand(repositoryBundle, commService, applicationContext);
         Output output = new Output();
 
         Question result = uut.execute(originalQuestion, wsContext, List.of("REDIT", Long.toString(roomId)), new Input("redit " + roomId), output);
 
-        assertEquals(room, attributes.get(REDIT_MODEL));
+        assertEquals(roomId, attributes.get(REDIT_MODEL));
         assertEquals(reditQuestion, result);
     }
 

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomExitsEditorQuestionTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomExitsEditorQuestionTest.java
@@ -24,6 +24,7 @@ import org.springframework.context.ApplicationContext;
 import java.util.*;
 
 import static com.agonyforge.mud.core.config.SessionConfiguration.MUD_CHARACTER;
+import static com.agonyforge.mud.demo.cli.question.ingame.olc.room.RoomEditorQuestion.REDIT_MODEL;
 import static com.agonyforge.mud.demo.cli.question.ingame.olc.room.RoomEditorQuestion.REDIT_STATE;
 import static com.agonyforge.mud.demo.cli.question.ingame.olc.room.RoomExitsEditorQuestion.REDIT_EXIT;
 import static org.junit.jupiter.api.Assertions.*;
@@ -56,9 +57,6 @@ public class RoomExitsEditorQuestionTest {
     private MudCharacter ch;
 
     @Mock
-    private LocationComponent locationComponent;
-
-    @Mock
     private MudRoom room;
 
     @Mock
@@ -76,13 +74,11 @@ public class RoomExitsEditorQuestionTest {
     @Test
     void testPromptMenu() {
         Long chId = RAND.nextLong();
-        long roomId = RAND.nextLong(100, 200);
         Map<String, Object> attributes = new HashMap<>();
 
         attributes.put(MUD_CHARACTER, chId);
+        attributes.put(REDIT_MODEL, room);
 
-        when(ch.getLocation()).thenReturn(locationComponent);
-        when(ch.getLocation().getRoom()).thenReturn(room);
         when(wsContext.getAttributes()).thenReturn(attributes);
 
         when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
@@ -96,14 +92,12 @@ public class RoomExitsEditorQuestionTest {
     @Test
     void testPromptExit() {
         Long chId = RAND.nextLong();
-        long roomId = RAND.nextLong(100, 200);
         Map<String, Object> attributes = new HashMap<>();
 
         attributes.put(MUD_CHARACTER, chId);
+        attributes.put(REDIT_MODEL, room);
         attributes.put(REDIT_STATE, "ROOM.EXITS");
 
-        when(ch.getLocation()).thenReturn(locationComponent);
-        when(ch.getLocation().getRoom()).thenReturn(room);
         when(wsContext.getAttributes()).thenReturn(attributes);
 
         when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
@@ -117,15 +111,13 @@ public class RoomExitsEditorQuestionTest {
     @Test
     void testAnswerExitDirection() {
         Long chId = RAND.nextLong();
-        long roomId = RAND.nextLong(100, 150);
         long destId = RAND.nextLong(150, 200);
         Map<String, Object> attributes = new HashMap<>();
 
         attributes.put(MUD_CHARACTER, chId);
+        attributes.put(REDIT_MODEL, room);
         attributes.put(REDIT_EXIT, Direction.NORTH);
 
-        when(ch.getLocation()).thenReturn(locationComponent);
-        when(ch.getLocation().getRoom()).thenReturn(room);
         when(wsContext.getAttributes()).thenReturn(attributes);
 
         when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
@@ -148,14 +140,12 @@ public class RoomExitsEditorQuestionTest {
     @Test
     void testAnswerExitDelete() {
         Long chId = RAND.nextLong();
-        long roomId = RAND.nextLong(100, 150);
         Map<String, Object> attributes = new HashMap<>();
 
         attributes.put(MUD_CHARACTER, chId);
+        attributes.put(REDIT_MODEL, room);
         attributes.put(REDIT_EXIT, Direction.NORTH);
 
-        when(ch.getLocation()).thenReturn(locationComponent);
-        when(ch.getLocation().getRoom()).thenReturn(room);
         when(wsContext.getAttributes()).thenReturn(attributes);
 
         when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
@@ -173,13 +163,11 @@ public class RoomExitsEditorQuestionTest {
     @Test
     void testAnswerChooseExit() {
         Long chId = RAND.nextLong();
-        long roomId = RAND.nextLong(100, 150);
         Map<String, Object> attributes = new HashMap<>();
 
         attributes.put(MUD_CHARACTER, chId);
+        attributes.put(REDIT_MODEL, room);
 
-        when(ch.getLocation()).thenReturn(locationComponent);
-        when(ch.getLocation().getRoom()).thenReturn(room);
         when(wsContext.getAttributes()).thenReturn(attributes);
 
         when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
@@ -198,13 +186,11 @@ public class RoomExitsEditorQuestionTest {
     @Test
     void testAnswerQuit() {
         Long chId = RAND.nextLong();
-        long roomId = RAND.nextLong(100, 150);
         Map<String, Object> attributes = new HashMap<>();
 
         attributes.put(MUD_CHARACTER, chId);
+        attributes.put(REDIT_MODEL, room);
 
-        when(ch.getLocation()).thenReturn(locationComponent);
-        when(ch.getLocation().getRoom()).thenReturn(room);
         when(wsContext.getAttributes()).thenReturn(attributes);
 
         when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomExitsEditorQuestionTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomExitsEditorQuestionTest.java
@@ -7,7 +7,6 @@ import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
 import com.agonyforge.mud.demo.model.constant.Direction;
-import com.agonyforge.mud.demo.model.impl.LocationComponent;
 import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import com.agonyforge.mud.demo.model.impl.MudRoom;
 import com.agonyforge.mud.demo.model.repository.MudCharacterRepository;
@@ -54,9 +53,6 @@ public class RoomExitsEditorQuestionTest {
     private Question question;
 
     @Mock
-    private MudCharacter ch;
-
-    @Mock
     private MudRoom room;
 
     @Mock
@@ -74,14 +70,14 @@ public class RoomExitsEditorQuestionTest {
     @Test
     void testPromptMenu() {
         Long chId = RAND.nextLong();
+        Long roomId = RAND.nextLong(100, 1000);
         Map<String, Object> attributes = new HashMap<>();
 
         attributes.put(MUD_CHARACTER, chId);
-        attributes.put(REDIT_MODEL, room);
+        attributes.put(REDIT_MODEL, roomId);
 
         when(wsContext.getAttributes()).thenReturn(attributes);
-
-        when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
+        when(roomRepository.findById(eq(roomId))).thenReturn(Optional.of(room));
 
         RoomExitsEditorQuestion uut = new RoomExitsEditorQuestion(applicationContext, repositoryBundle);
         Output output = uut.prompt(wsContext);
@@ -92,15 +88,15 @@ public class RoomExitsEditorQuestionTest {
     @Test
     void testPromptExit() {
         Long chId = RAND.nextLong();
+        Long roomId = RAND.nextLong(100, 1000);
         Map<String, Object> attributes = new HashMap<>();
 
         attributes.put(MUD_CHARACTER, chId);
-        attributes.put(REDIT_MODEL, room);
+        attributes.put(REDIT_MODEL, roomId);
         attributes.put(REDIT_STATE, "ROOM.EXITS");
 
         when(wsContext.getAttributes()).thenReturn(attributes);
-
-        when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
+        when(roomRepository.findById(eq(roomId))).thenReturn(Optional.of(room));
 
         RoomExitsEditorQuestion uut = new RoomExitsEditorQuestion(applicationContext, repositoryBundle);
         Output output = uut.prompt(wsContext);
@@ -111,16 +107,16 @@ public class RoomExitsEditorQuestionTest {
     @Test
     void testAnswerExitDirection() {
         Long chId = RAND.nextLong();
+        Long roomId = RAND.nextLong(100, 1000);
         long destId = RAND.nextLong(150, 200);
         Map<String, Object> attributes = new HashMap<>();
 
         attributes.put(MUD_CHARACTER, chId);
-        attributes.put(REDIT_MODEL, room);
+        attributes.put(REDIT_MODEL, roomId);
         attributes.put(REDIT_EXIT, Direction.NORTH);
 
         when(wsContext.getAttributes()).thenReturn(attributes);
-
-        when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
+        when(roomRepository.findById(eq(roomId))).thenReturn(Optional.of(room));
         when(roomRepository.findById(eq(destId))).thenReturn(Optional.of(destRoom));
         when(applicationContext.getBean(eq("roomExitsEditorQuestion"), eq(Question.class))).thenReturn(question);
 
@@ -140,15 +136,15 @@ public class RoomExitsEditorQuestionTest {
     @Test
     void testAnswerExitDelete() {
         Long chId = RAND.nextLong();
+        Long roomId = RAND.nextLong(100, 1000);
         Map<String, Object> attributes = new HashMap<>();
 
         attributes.put(MUD_CHARACTER, chId);
-        attributes.put(REDIT_MODEL, room);
+        attributes.put(REDIT_MODEL, roomId);
         attributes.put(REDIT_EXIT, Direction.NORTH);
 
         when(wsContext.getAttributes()).thenReturn(attributes);
-
-        when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
+        when(roomRepository.findById(eq(roomId))).thenReturn(Optional.of(room));
         when(applicationContext.getBean(eq("roomExitsEditorQuestion"), eq(Question.class))).thenReturn(question);
 
         RoomExitsEditorQuestion uut = new RoomExitsEditorQuestion(applicationContext, repositoryBundle);
@@ -163,14 +159,14 @@ public class RoomExitsEditorQuestionTest {
     @Test
     void testAnswerChooseExit() {
         Long chId = RAND.nextLong();
+        Long roomId = RAND.nextLong(100, 1000);
         Map<String, Object> attributes = new HashMap<>();
 
         attributes.put(MUD_CHARACTER, chId);
-        attributes.put(REDIT_MODEL, room);
+        attributes.put(REDIT_MODEL, roomId);
 
         when(wsContext.getAttributes()).thenReturn(attributes);
-
-        when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
+        when(roomRepository.findById(eq(roomId))).thenReturn(Optional.of(room));
         when(applicationContext.getBean(eq("roomExitsEditorQuestion"), eq(Question.class))).thenReturn(question);
 
         RoomExitsEditorQuestion uut = new RoomExitsEditorQuestion(applicationContext, repositoryBundle);
@@ -186,14 +182,14 @@ public class RoomExitsEditorQuestionTest {
     @Test
     void testAnswerQuit() {
         Long chId = RAND.nextLong();
+        Long roomId = RAND.nextLong(100, 1000);
         Map<String, Object> attributes = new HashMap<>();
 
         attributes.put(MUD_CHARACTER, chId);
-        attributes.put(REDIT_MODEL, room);
+        attributes.put(REDIT_MODEL, roomId);
 
         when(wsContext.getAttributes()).thenReturn(attributes);
-
-        when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
+        when(roomRepository.findById(eq(roomId))).thenReturn(Optional.of(room));
         when(applicationContext.getBean(eq("roomEditorQuestion"), eq(Question.class))).thenReturn(question);
 
         RoomExitsEditorQuestion uut = new RoomExitsEditorQuestion(applicationContext, repositoryBundle);

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomFlagsEditorQuestionTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/ingame/olc/room/RoomFlagsEditorQuestionTest.java
@@ -22,10 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationContext;
 
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static com.agonyforge.mud.core.config.SessionConfiguration.MUD_CHARACTER;
 import static com.agonyforge.mud.demo.cli.question.ingame.olc.room.RoomEditorQuestion.REDIT_MODEL;
@@ -37,6 +34,8 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class RoomFlagsEditorQuestionTest {
+    private static final Random RAND = new Random();
+
     @Mock
     private RepositoryBundle repositoryBundle;
 
@@ -85,10 +84,13 @@ public class RoomFlagsEditorQuestionTest {
 
     @Test
     void testPrompt() {
+        Long roomId = RAND.nextLong(100, 1000);
+
+        when(mudRoomRepository.findById(eq(roomId))).thenReturn(Optional.of(room));
         when(room.getFlags()).thenReturn(EnumSet.noneOf(RoomFlag.class));
         when(webSocketContext.getAttributes()).thenReturn(Map.of(
             MUD_CHARACTER, 65L,
-            REDIT_MODEL, room
+            REDIT_MODEL, roomId
         ));
 
         RoomFlagsEditorQuestion uut = new RoomFlagsEditorQuestion(applicationContext, repositoryBundle);
@@ -99,13 +101,15 @@ public class RoomFlagsEditorQuestionTest {
 
     @Test
     void testPromptToggleOn() {
+        Long roomId = RAND.nextLong(100, 1000);
         Map<String, Object> attributes = new HashMap<>();
         EnumSet<RoomFlag> flags = EnumSet.noneOf(RoomFlag.class);
 
-        attributes.put(REDIT_MODEL, room);
+        attributes.put(REDIT_MODEL, roomId);
         attributes.put(REDIT_STATE, REDIT_FLAG);
         attributes.put(REDIT_FLAG, RoomFlag.INDOORS);
 
+        when(mudRoomRepository.findById(eq(roomId))).thenReturn(Optional.of(room));
         when(webSocketContext.getAttributes()).thenReturn(attributes);
         when(room.getFlags()).thenReturn(flags);
 
@@ -120,13 +124,15 @@ public class RoomFlagsEditorQuestionTest {
 
     @Test
     void testPromptToggleOff() {
+        Long roomId = RAND.nextLong(100, 1000);
         Map<String, Object> attributes = new HashMap<>();
         EnumSet<RoomFlag> flags = EnumSet.of(RoomFlag.INDOORS);
 
-        attributes.put(REDIT_MODEL, room);
+        attributes.put(REDIT_MODEL, roomId);
         attributes.put(REDIT_STATE, REDIT_FLAG);
         attributes.put(REDIT_FLAG, RoomFlag.INDOORS);
 
+        when(mudRoomRepository.findById(eq(roomId))).thenReturn(Optional.of(room));
         when(webSocketContext.getAttributes()).thenReturn(attributes);
         when(room.getFlags()).thenReturn(flags);
 
@@ -142,10 +148,12 @@ public class RoomFlagsEditorQuestionTest {
     @ParameterizedTest
     @ValueSource(strings = { "1" })
     void testAnswer(String input) {
+        Long roomId = RAND.nextLong(100, 1000);
         Map<String, Object> attributes = new HashMap<>();
 
-        attributes.put(REDIT_MODEL, room);
+        attributes.put(REDIT_MODEL, roomId);
 
+        when(mudRoomRepository.findById(eq(roomId))).thenReturn(Optional.of(room));
         when(webSocketContext.getAttributes()).thenReturn(attributes);
         when(room.getFlags()).thenReturn(EnumSet.noneOf(RoomFlag.class));
 
@@ -162,10 +170,12 @@ public class RoomFlagsEditorQuestionTest {
     @ParameterizedTest
     @ValueSource(strings = { "0", "T", "💀" })
     void testAnswerInvalid(String input) {
+        Long roomId = RAND.nextLong(100, 1000);
         Map<String, Object> attributes = new HashMap<>();
 
-        attributes.put(REDIT_MODEL, room);
+        attributes.put(REDIT_MODEL, roomId);
 
+        when(mudRoomRepository.findById(eq(roomId))).thenReturn(Optional.of(room));
         when(webSocketContext.getAttributes()).thenReturn(attributes);
         when(room.getFlags()).thenReturn(EnumSet.noneOf(RoomFlag.class));
 
@@ -182,9 +192,10 @@ public class RoomFlagsEditorQuestionTest {
 
     @Test
     void testAnswerExit() {
+        Long roomId = RAND.nextLong(100, 1000);
         Map<String, Object> attributes = new HashMap<>();
 
-        attributes.put(REDIT_MODEL, room);
+        attributes.put(REDIT_MODEL, roomId);
         attributes.put(REDIT_FLAG, RoomFlag.INDOORS);
 
         when(webSocketContext.getAttributes()).thenReturn(attributes);


### PR DESCRIPTION
Fixes #410 
Fixes #418 

The two bugs were related. Now when you REDIT a room you aren't standing in, the exits menu will edit the correct room.