### PR TITLE
Tokenizer should skip color codes

### DIFF
--- a/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/cli/Tokenizer.java
+++ b/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/cli/Tokenizer.java
@@ -11,12 +11,19 @@ public class Tokenizer {
         List<String> tokens = new ArrayList<>();
         StringBuilder buf = new StringBuilder();
         boolean isQuoting = false;
+        boolean isColor = false;
 
         String input = HtmlUtils.htmlUnescape(escaped).trim();
 
         for (int i = 0; i < input.length(); i++) {
             if (input.charAt(i) == '"') {
                 isQuoting = !isQuoting;
+            } else if (input.charAt(i) == '[') {
+                isColor = true;
+            } else if (input.charAt(i) == ']') {
+                isColor = false;
+            } else if (isColor) {
+                // do nothing
             } else if (!isQuoting && input.charAt(i) == ' ') {
                 addTokenIfNotBlank(tokens, buf);
                 buf.setLength(0);

--- a/agonyforge-mud-core/src/test/java/com/agonyforge/mud/core/cli/TokenizerTest.java
+++ b/agonyforge-mud-core/src/test/java/com/agonyforge/mud/core/cli/TokenizerTest.java
@@ -46,4 +46,12 @@ public class TokenizerTest {
 
         assertEquals(expected, Tokenizer.tokenize(input));
     }
+
+    @Test
+    void testTokenizeColorCodes() {
+        String input = "[red]able baker [blue]charlie";
+        List<String> expected = List.of("ABLE", "BAKER", "CHARLIE");
+
+        assertEquals(expected, Tokenizer.tokenize(input));
+    }
 }


### PR DESCRIPTION
Fixes #404 

The Tokenizer now skips over color codes.
Before: `purge [green]sword` becomes `PURGE, [GREEN]SWORD`
After: `purge [green]sword` becomes `PURGE, SWORD`