### PR TITLE
CEDIT: a simple command editor

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/Command.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/Command.java
@@ -24,6 +24,14 @@ public interface Command {
         return input.substring(space + 1).stripLeading();
     }
 
+    static String stripFirstWords(String input, int words) {
+        for (int i = 0; i < words; i++) {
+            input = stripFirstWord(input);
+        }
+
+        return input;
+    }
+
     static String stripColors(String input) {
         boolean inColor = false;
         StringBuilder out = new StringBuilder();

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/CommandEditorCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/CommandEditorCommand.java
@@ -1,0 +1,110 @@
+package com.agonyforge.mud.demo.cli.command;
+
+import com.agonyforge.mud.core.cli.Question;
+import com.agonyforge.mud.core.web.model.Input;
+import com.agonyforge.mud.core.web.model.Output;
+import com.agonyforge.mud.core.web.model.WebSocketContext;
+import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.impl.CommandReference;
+import com.agonyforge.mud.demo.model.repository.CommandRepository;
+import com.agonyforge.mud.demo.service.CommService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+@Component
+public class CommandEditorCommand extends AbstractCommand {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommandEditorCommand.class);
+
+    private final CommandRepository commandRepository;
+
+    @Autowired
+    public CommandEditorCommand(RepositoryBundle repositoryBundle,
+                                CommandRepository commandRepository,
+                                CommService commService,
+                                ApplicationContext applicationContext) {
+        super(repositoryBundle, commService, applicationContext);
+        this.commandRepository = commandRepository;
+    }
+
+    @Override
+    public Question execute(Question question, WebSocketContext webSocketContext, List<String> tokens, Input input, Output output) {
+        if (tokens.size() <= 1) {
+            output.append("[white]%-4s [white]%-12s [white]%-20s [white]%s", "Pri", "Command", "Bean Name", "Description");
+
+            commandRepository.findAll().stream()
+                .sorted(Comparator.comparingInt(CommandReference::getPriority))
+                .forEachOrdered(cmd -> output.append("[green]%-4d [yellow]%-12s [dyellow]%-20s [dgreen]%s",
+                    cmd.getPriority(),
+                    cmd.getName().toUpperCase(Locale.ROOT),
+                    cmd.getBeanName(),
+                    cmd.getDescription()));
+
+            return question;
+        }
+
+        String subCommand = tokens.get(1);
+
+        if ("CREATE".equals(subCommand)) {
+            // CEDIT CREATE <name> <priority> <beanName> <description>
+            if (tokens.size() <= 5) {
+                output.append("[yellow]CEDIT CREATE &lt;name&gt; &lt;priority&gt; &lt;beanName&gt; &lt;description&gt;");
+            } else {
+                try {
+                    String[] rawTokens = StringUtils.tokenizeToStringArray(input.getInput(), " ", true, true);
+                    String name = tokens.get(2);
+                    int priority = Integer.parseInt(tokens.get(3));
+                    String beanName = rawTokens[4];
+                    String description = Command.stripFirstWords(input.getInput(), 5);
+                    CommandReference command = new CommandReference();
+
+                    // throws exception if bean cannot be found
+                    getApplicationContext().getBean(beanName, CommandReference.class);
+
+                    command.setName(name);
+                    command.setPriority(priority);
+                    command.setBeanName(beanName);
+                    command.setDescription(description);
+
+                    commandRepository.save(command);
+
+                    output.append("[green]Created %s command!", command.getName());
+                } catch (NumberFormatException e) {
+                    output.append("[red]Priority must be a number.");
+                } catch (BeansException e) {
+                    output.append("[red]No command bean could be found with that name.");
+                }
+            }
+        } else if ("DELETE".equals(subCommand)) {
+            // CEDIT DELETE <name>
+            if (tokens.size() != 3) {
+                output.append("[yellow]CEDIT DELETE &lt;name&gt;");
+            } else {
+                String name = Command.stripFirstWords(input.getInput(), 2);
+                Optional<CommandReference> commandOptional = commandRepository.findByName(name);
+
+                if (commandOptional.isPresent()) {
+                    commandRepository.delete(commandOptional.get());
+                    output.append("[yellow]Deleted command: %s", commandOptional.get().getName());
+                } else {
+                    output.append("[red]Unknown command: %s", name);
+                }
+            }
+        } else {
+            output
+                .append("[yellow]Invalid subcommand.")
+                .append("[yellow]Try with no arguments, CREATE or DELETE.");
+        }
+
+        return question;
+    }
+}

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
@@ -77,6 +77,7 @@ public class CommandLoader {
             refs.put("REDIT", new CommandReference(20, "REDIT", "roomEditorCommand", "Edit a room."));
             refs.put("IEDIT", new CommandReference(20, "IEDIT", "itemEditorCommand", "Edit an item."));
             refs.put("MEDIT", new CommandReference(20, "MEDIT", "nonPlayerCreatureEditorCommand", "Edit a creature."));
+            refs.put("CEDIT", new CommandReference(20, "CEDIT", "commandEditorCommand", "Edit commands."));
 
             refs.put("GOTO", new CommandReference(30, "GOTO", "gotoCommand", "Go to a room or player."));
             refs.put("TRANSFER", new CommandReference(30, "TRANSFER", "transferCommand", "Bring a player to you."));

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/repository/CommandRepository.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/repository/CommandRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 
 @Repository
 public interface CommandRepository extends JpaRepository<CommandReference, String> {
+    Optional<CommandReference> findByName(String name);
     Optional<CommandReference> findFirstByNameStartingWith(String name, Sort sort);
 }

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/CommandEditorCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/CommandEditorCommandTest.java
@@ -1,0 +1,235 @@
+package com.agonyforge.mud.demo.cli.command;
+
+import com.agonyforge.mud.core.cli.Question;
+import com.agonyforge.mud.core.web.model.Input;
+import com.agonyforge.mud.core.web.model.Output;
+import com.agonyforge.mud.core.web.model.WebSocketContext;
+import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.impl.CommandReference;
+import com.agonyforge.mud.demo.model.repository.CommandRepository;
+import com.agonyforge.mud.demo.service.CommService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CommandEditorCommandTest {
+    @Mock
+    private ApplicationContext applicationContext;
+
+    @Mock
+    private RepositoryBundle repositoryBundle;
+
+    @Mock
+    private CommService commService;
+
+    @Mock
+    private CommandRepository commandRepository;
+
+    @Mock
+    private Question question;
+
+    @Mock
+    private WebSocketContext webSocketContext;
+
+    @Mock
+    private CommandReference commandRef;
+
+    @Captor
+    private ArgumentCaptor<CommandReference> commandRefCaptor;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(commandRef.getPriority()).thenReturn(1);
+        lenient().when(commandRef.getName()).thenReturn("test");
+        lenient().when(commandRef.getBeanName()).thenReturn("testCommand");
+        lenient().when(commandRef.getDescription()).thenReturn("Tests things.");
+
+        lenient().when(commandRepository.findByName(eq("test"))).thenReturn(Optional.of(commandRef));
+        lenient().when(commandRepository.findAll()).thenReturn(List.of(commandRef));
+        lenient().when(commandRepository.save(any(CommandReference.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        lenient().when(applicationContext.getBean(eq("testCommand"), eq(CommandReference.class))).thenReturn(commandRef);
+        lenient().when(applicationContext.getBean(eq("missingCommand"), eq(CommandReference.class))).thenThrow(new NoSuchBeanDefinitionException("Aw nuts!"));
+    }
+
+    @Test
+    void testNoArgs() {
+        Output output = new Output();
+        CommandEditorCommand uut = new CommandEditorCommand(repositoryBundle, commandRepository, commService, applicationContext);
+        Question result = uut.execute(question, webSocketContext, List.of("CEDIT"), new Input("cedit"), output);
+
+        assertEquals(question, result);
+        assertTrue(output.getOutput().stream().anyMatch(line -> line.contains("Pri")));
+        assertTrue(output.getOutput().stream().anyMatch(line -> line.contains("Command")));
+        assertTrue(output.getOutput().stream().anyMatch(line -> line.contains("Bean Name")));
+        assertTrue(output.getOutput().stream().anyMatch(line -> line.contains("Description")));
+        assertTrue(output.getOutput().stream().anyMatch(line -> line.contains("Tests things.")));
+
+        verify(commandRepository, never()).save(any(CommandReference.class));
+        verify(commandRepository, never()).delete(any(CommandReference.class));
+    }
+
+    @Test
+    void testInvalidSubcommand() {
+        Output output = new Output();
+        CommandEditorCommand uut = new CommandEditorCommand(repositoryBundle, commandRepository, commService, applicationContext);
+        Question result = uut.execute(question, webSocketContext, List.of("CEDIT", "TEST"), new Input("cedit test"), output);
+
+        assertEquals(question, result);
+        assertTrue(output.getOutput().stream().anyMatch(line -> line.contains("Invalid subcommand.")));
+
+        verify(commandRepository, never()).save(any(CommandReference.class));
+        verify(commandRepository, never()).delete(any(CommandReference.class));
+    }
+
+    @Test
+    void testCreate() {
+        Output output = new Output();
+        CommandEditorCommand uut = new CommandEditorCommand(repositoryBundle, commandRepository, commService, applicationContext);
+        Question result = uut.execute(question, webSocketContext,
+            List.of("CEDIT", "CREATE", "TEST", "50", "TESTCOMMAND", "TESTS", "STUFF"),
+            new Input("cedit create test 50 testCommand Tests stuff"),
+            output);
+
+        assertEquals(question, result);
+        assertTrue(output.getOutput().stream().anyMatch(line -> line.contains("Created TEST command")));
+
+        verify(commandRepository).save(commandRefCaptor.capture());
+        verify(commandRepository, never()).delete(any(CommandReference.class));
+
+        CommandReference capturedCommand = commandRefCaptor.getValue();
+
+        assertEquals("TEST", capturedCommand.getName());
+        assertEquals(50, capturedCommand.getPriority());
+        assertEquals("testCommand", capturedCommand.getBeanName());
+        assertEquals("Tests stuff", capturedCommand.getDescription());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "cedit create",
+        "cedit create test",
+        "cedit create test 50",
+        "cedit create test fifty",
+        "cedit create test 50 testCommand",
+        "cedit create test fifty testCommand"
+    })
+    void testCreateWrongArgs(String input) {
+        Output output = new Output();
+        CommandEditorCommand uut = new CommandEditorCommand(repositoryBundle, commandRepository, commService, applicationContext);
+        Question result = uut.execute(question, webSocketContext,
+            Arrays.stream(StringUtils.tokenizeToStringArray(input.toUpperCase(Locale.ROOT), " ", true, true)).toList(),
+            new Input(input),
+            output);
+
+        assertEquals(question, result);
+        assertTrue(output.getOutput().stream().anyMatch(line -> line.contains("CEDIT CREATE")));
+
+        verify(commandRepository, never()).save(any(CommandReference.class));
+        verify(commandRepository, never()).delete(any(CommandReference.class));
+    }
+
+    @Test
+    void testCreateWrongPriority() {
+        Output output = new Output();
+        CommandEditorCommand uut = new CommandEditorCommand(repositoryBundle, commandRepository, commService, applicationContext);
+        Question result = uut.execute(question, webSocketContext,
+            List.of("CEDIT", "CREATE", "TEST", "FIFTY", "TESTCOMMAND", "DESCRIPTION"),
+            new Input("cedit create test fifty testCommand description"),
+            output);
+
+        assertEquals(question, result);
+        assertTrue(output.getOutput().stream().anyMatch(line -> line.contains("Priority must be a number")));
+
+        verify(commandRepository, never()).save(any(CommandReference.class));
+        verify(commandRepository, never()).delete(any(CommandReference.class));
+    }
+
+    @Test
+    void testCreateMissingBean() {
+        Output output = new Output();
+        CommandEditorCommand uut = new CommandEditorCommand(repositoryBundle, commandRepository, commService, applicationContext);
+        Question result = uut.execute(question, webSocketContext,
+            List.of("CEDIT", "CREATE", "TEST", "50", "MISSINGCOMMAND", "TESTS", "STUFF"),
+            new Input("cedit create test 50 missingCommand Tests stuff"),
+            output);
+
+        assertEquals(question, result);
+        assertTrue(output.getOutput().stream().anyMatch(line -> line.contains("No command bean could be found with that name")));
+
+        verify(commandRepository, never()).save(any(CommandReference.class));
+        verify(commandRepository, never()).delete(any(CommandReference.class));
+    }
+
+    @Test
+    void testDelete() {
+        Output output = new Output();
+        CommandEditorCommand uut = new CommandEditorCommand(repositoryBundle, commandRepository, commService, applicationContext);
+        Question result = uut.execute(question, webSocketContext,
+            List.of("CEDIT", "DELETE", "TEST"),
+            new Input("cedit delete test"),
+            output);
+
+        assertEquals(question, result);
+
+        verify(commandRepository, never()).save(any(CommandReference.class));
+        verify(commandRepository).delete(any(CommandReference.class));
+    }
+
+    @Test
+    void testDeleteMissingCommand() {
+        Output output = new Output();
+        CommandEditorCommand uut = new CommandEditorCommand(repositoryBundle, commandRepository, commService, applicationContext);
+        Question result = uut.execute(question, webSocketContext,
+            List.of("CEDIT", "DELETE", "WRONG"),
+            new Input("cedit delete wrong"),
+            output);
+
+        assertEquals(question, result);
+        assertTrue(output.getOutput().stream().anyMatch(line -> line.contains("Unknown command")));
+
+        verify(commandRepository, never()).save(any(CommandReference.class));
+        verify(commandRepository, never()).delete(any(CommandReference.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "cedit delete",
+        "cedit delete test foo"
+    })
+    void testDeleteWrongArgs(String input) {
+        Output output = new Output();
+        CommandEditorCommand uut = new CommandEditorCommand(repositoryBundle, commandRepository, commService, applicationContext);
+        Question result = uut.execute(question, webSocketContext,
+            Arrays.stream(StringUtils.tokenizeToStringArray(input.toUpperCase(Locale.ROOT), " ", true, true)).toList(),
+            new Input(input),
+            output);
+
+        assertEquals(question, result);
+        assertTrue(output.getOutput().stream().anyMatch(line -> line.contains("CEDIT DELETE")));
+
+        verify(commandRepository, never()).save(any(CommandReference.class));
+        verify(commandRepository, never()).delete(any(CommandReference.class));
+    }
+}


### PR DESCRIPTION
An in-game editor for configuring commands. Each command is a Spring bean and there is a `CommandReference` that maps the name of the command (e.g. "NORTH") to the bean (e.g. "moveCommand") and stores information such as the priority and description.

Until now we've relied on the `CommandLoader` to create all the `CommandReference` objects whenever the database is empty. CEDIT makes it so that you can create and delete `CommandReference` objects in the database from inside the game without needing to empty your database so that `CommandLoader` will do it.

I still plan to keep `CommandLoader` up to date so that fresh databases create all the commands. Otherwise you'd have to manually create CEDIT and then use it to create every command, which isn't fun. But this way if you make a new command and don't want to clear your database, you can do it without manually running SQL queries. Or if you want to rename a command, change its priority, update its description, you can do that by deleting and re-creating the command.

Future improvements will likely include being able to rename, reprioritize and change the description of commands in one step instead of a delete and then a create, but this is a good start.