### PR TITLE
mistaken CommandReference instead of Command in test mocks led to bug

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/CommandEditorCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/CommandEditorCommand.java
@@ -68,7 +68,7 @@ public class CommandEditorCommand extends AbstractCommand {
                     CommandReference command = new CommandReference();
 
                     // throws exception if bean cannot be found
-                    getApplicationContext().getBean(beanName, CommandReference.class);
+                    getApplicationContext().getBean(beanName, Command.class);
 
                     command.setName(name);
                     command.setPriority(priority);

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/CommandEditorCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/CommandEditorCommand.java
@@ -8,8 +8,6 @@ import com.agonyforge.mud.demo.cli.RepositoryBundle;
 import com.agonyforge.mud.demo.model.impl.CommandReference;
 import com.agonyforge.mud.demo.model.repository.CommandRepository;
 import com.agonyforge.mud.demo.service.CommService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -23,8 +21,6 @@ import java.util.Optional;
 
 @Component
 public class CommandEditorCommand extends AbstractCommand {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CommandEditorCommand.class);
-
     private final CommandRepository commandRepository;
 
     @Autowired
@@ -90,7 +86,7 @@ public class CommandEditorCommand extends AbstractCommand {
                 output.append("[yellow]CEDIT DELETE &lt;name&gt;");
             } else {
                 String name = Command.stripFirstWords(input.getInput(), 2);
-                Optional<CommandReference> commandOptional = commandRepository.findByName(name);
+                Optional<CommandReference> commandOptional = commandRepository.findByNameIgnoreCase(name);
 
                 if (commandOptional.isPresent()) {
                     commandRepository.delete(commandOptional.get());

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/repository/CommandRepository.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/repository/CommandRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 
 @Repository
 public interface CommandRepository extends JpaRepository<CommandReference, String> {
-    Optional<CommandReference> findByName(String name);
+    Optional<CommandReference> findByNameIgnoreCase(String name);
     Optional<CommandReference> findFirstByNameStartingWith(String name, Sort sort);
 }

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/CommandEditorCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/CommandEditorCommandTest.java
@@ -55,6 +55,9 @@ public class CommandEditorCommandTest {
     @Mock
     private CommandReference commandRef;
 
+    @Mock
+    private Command command;
+
     @Captor
     private ArgumentCaptor<CommandReference> commandRefCaptor;
 
@@ -69,8 +72,8 @@ public class CommandEditorCommandTest {
         lenient().when(commandRepository.findAll()).thenReturn(List.of(commandRef));
         lenient().when(commandRepository.save(any(CommandReference.class))).thenAnswer(i -> i.getArguments()[0]);
 
-        lenient().when(applicationContext.getBean(eq("testCommand"), eq(CommandReference.class))).thenReturn(commandRef);
-        lenient().when(applicationContext.getBean(eq("missingCommand"), eq(CommandReference.class))).thenThrow(new NoSuchBeanDefinitionException("Aw nuts!"));
+        lenient().when(applicationContext.getBean(eq("testCommand"), eq(Command.class))).thenReturn(command);
+        lenient().when(applicationContext.getBean(eq("missingCommand"), eq(Command.class))).thenThrow(new NoSuchBeanDefinitionException("Aw nuts!"));
     }
 
     @Test

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/CommandEditorCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/CommandEditorCommandTest.java
@@ -64,11 +64,11 @@ public class CommandEditorCommandTest {
     @BeforeEach
     void setUp() {
         lenient().when(commandRef.getPriority()).thenReturn(1);
-        lenient().when(commandRef.getName()).thenReturn("test");
+        lenient().when(commandRef.getName()).thenReturn("TEST");
         lenient().when(commandRef.getBeanName()).thenReturn("testCommand");
         lenient().when(commandRef.getDescription()).thenReturn("Tests things.");
 
-        lenient().when(commandRepository.findByName(eq("test"))).thenReturn(Optional.of(commandRef));
+        lenient().when(commandRepository.findByNameIgnoreCase(eq("test"))).thenReturn(Optional.of(commandRef));
         lenient().when(commandRepository.findAll()).thenReturn(List.of(commandRef));
         lenient().when(commandRepository.save(any(CommandReference.class))).thenAnswer(i -> i.getArguments()[0]);
 


### PR DESCRIPTION
CEDIT CREATE didn't work properly because I had set up my tests with a `CommandReference` where a `Command` should have been. The tests passed but the command didn't work in practice.