### PR TITLE
Holylight Admin Flag

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/ConfigCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/ConfigCommand.java
@@ -5,7 +5,7 @@ import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
-import com.agonyforge.mud.demo.model.constant.PlayerFlag;
+import com.agonyforge.mud.demo.model.constant.AdminFlag;
 import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import com.agonyforge.mud.demo.service.CommService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,13 +28,13 @@ public class ConfigCommand extends AbstractCommand {
 
         if (tokens.size() == 1) {
             output.append("[yellow]Admin Configuration Flags:");
-            Arrays.stream(PlayerFlag.values()).forEachOrdered(flag -> {
+            Arrays.stream(AdminFlag.values()).forEachOrdered(flag -> {
                 boolean isEnabled = ch.getPlayer().getAdminFlags().contains(flag);
 
                 output.append("[yellow]%s: %s", flag.name(), isEnabled);
             });
         } else if (tokens.size() == 2) {
-            PlayerFlag flag = PlayerFlag.valueOf(tokens.get(1));
+            AdminFlag flag = AdminFlag.valueOf(tokens.get(1));
 
             if (ch.getPlayer().getAdminFlags().contains(flag)) {
                 ch.getPlayer().getAdminFlags().remove(flag);

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/ConfigCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/ConfigCommand.java
@@ -1,0 +1,50 @@
+package com.agonyforge.mud.demo.cli.command;
+
+import com.agonyforge.mud.core.cli.Question;
+import com.agonyforge.mud.core.web.model.Input;
+import com.agonyforge.mud.core.web.model.Output;
+import com.agonyforge.mud.core.web.model.WebSocketContext;
+import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.PlayerFlag;
+import com.agonyforge.mud.demo.model.impl.MudCharacter;
+import com.agonyforge.mud.demo.service.CommService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class ConfigCommand extends AbstractCommand {
+    @Autowired
+    public ConfigCommand(RepositoryBundle repositoryBundle, CommService commService, ApplicationContext applicationContext) {
+        super(repositoryBundle, commService, applicationContext);
+    }
+
+    @Override
+    public Question execute(Question question, WebSocketContext webSocketContext, List<String> tokens, Input input, Output output) {
+        MudCharacter ch = getCurrentCharacter(webSocketContext, output);
+
+        if (tokens.size() == 1) {
+            output.append("[yellow]Admin Configuration Flags:");
+            Arrays.stream(PlayerFlag.values()).forEachOrdered(flag -> {
+                boolean isEnabled = ch.getPlayer().getAdminFlags().contains(flag);
+
+                output.append("[yellow]%s: %s", flag.name(), isEnabled);
+            });
+        } else if (tokens.size() == 2) {
+            PlayerFlag flag = PlayerFlag.valueOf(tokens.get(1));
+
+            if (ch.getPlayer().getAdminFlags().contains(flag)) {
+                ch.getPlayer().getAdminFlags().remove(flag);
+                output.append("[yellow]%s disabled.", flag.name());
+            } else {
+                ch.getPlayer().getAdminFlags().add(flag);
+                output.append("[yellow]%s enabled.", flag.name());
+            }
+        }
+
+        return question;
+    }
+}

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/LookCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/LookCommand.java
@@ -6,6 +6,7 @@ import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.AdminFlag;
 import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import com.agonyforge.mud.demo.model.impl.MudRoom;
 import com.agonyforge.mud.demo.service.CommService;
@@ -32,8 +33,13 @@ public class LookCommand extends AbstractCommand {
 
         Output output = new Output();
 
+        if (ch.getPlayer() != null && ch.getPlayer().getAdminFlags().contains(AdminFlag.HOLYLIGHT)) {
+            output.append("[yellow](%d) %s %s", room.getId(), room.getName(), room.getFlags());
+        } else {
+            output.append("[yellow]%s", room.getName());
+        }
+
         output
-            .append("[yellow](%d) %s %s", room.getId(), room.getName(), room.getFlags())
             .append("[default]%s", room.getDescription())
             .append("[dcyan]Exits: %s", String.join(" ", room.getExits()));
 
@@ -63,7 +69,7 @@ public class LookCommand extends AbstractCommand {
                     action = "here";
                 }
 
-                if (target.getPlayer() != null) {
+                if (target.getPlayer() != null || (ch.getPlayer() != null && !ch.getPlayer().getAdminFlags().contains(AdminFlag.HOLYLIGHT))) {
                     output.append("[green]%s is %s. %s", StringUtils.capitalize(target.getCharacter().getName()), action, flags);
                 } else {
                     output.append("[green](%d) %s is %s.", target.getTemplate().getId(), StringUtils.capitalize(target.getCharacter().getName()), action, flags);
@@ -71,9 +77,15 @@ public class LookCommand extends AbstractCommand {
             });
 
         repositoryBundle.getItemRepository().findByLocationRoom(room)
-            .forEach(target -> output.append("[green](%d) %s",
-                target.getTemplate().getId(),
-                StringUtils.capitalize(target.getItem().getLongDescription())));
+            .forEach(target -> {
+                if (ch.getPlayer() != null && ch.getPlayer().getAdminFlags().contains(AdminFlag.HOLYLIGHT)) {
+                    output.append("[green](%d) %s",
+                        target.getTemplate().getId(),
+                        StringUtils.capitalize(target.getItem().getLongDescription()));
+                } else {
+                    output.append("[green]%s", StringUtils.capitalize(target.getItem().getLongDescription()));
+                }
+            });
 
         return output;
     }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
@@ -79,6 +79,7 @@ public class CommandLoader {
             refs.put("MEDIT", new CommandReference(20, "MEDIT", "nonPlayerCreatureEditorCommand", "Edit a creature."));
             refs.put("CEDIT", new CommandReference(20, "CEDIT", "commandEditorCommand", "Edit commands."));
 
+            refs.put("CONFIG", new CommandReference(30, "CONFIG", "configCommand", "Configure admin preferences."));
             refs.put("GOTO", new CommandReference(30, "GOTO", "gotoCommand", "Go to a room or player."));
             refs.put("TRANSFER", new CommandReference(30, "TRANSFER", "transferCommand", "Bring a player to you."));
             refs.put("TELEPORT", new CommandReference(30, "TELEPORT", "teleportCommand", "Send a player to a room."));

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/constant/AdminFlag.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/constant/AdminFlag.java
@@ -3,12 +3,12 @@ package com.agonyforge.mud.demo.model.constant;
 import com.agonyforge.mud.demo.model.util.BaseEnumSetConverter;
 import com.agonyforge.mud.demo.model.util.PersistentEnum;
 
-public enum PlayerFlag implements PersistentEnum {
+public enum AdminFlag implements PersistentEnum {
     HOLYLIGHT("can see everything");
 
     private final String description;
 
-    PlayerFlag(String description) {
+    AdminFlag(String description) {
         this.description = description;
     }
 
@@ -16,9 +16,9 @@ public enum PlayerFlag implements PersistentEnum {
         return description;
     }
 
-    public static class Converter extends BaseEnumSetConverter<PlayerFlag> {
+    public static class Converter extends BaseEnumSetConverter<AdminFlag> {
         public Converter() {
-            super(PlayerFlag.class);
+            super(AdminFlag.class);
         }
     }
 }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/constant/PlayerFlag.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/constant/PlayerFlag.java
@@ -1,0 +1,24 @@
+package com.agonyforge.mud.demo.model.constant;
+
+import com.agonyforge.mud.demo.model.util.BaseEnumSetConverter;
+import com.agonyforge.mud.demo.model.util.PersistentEnum;
+
+public enum PlayerFlag implements PersistentEnum {
+    HOLYLIGHT("can see everything");
+
+    private final String description;
+
+    PlayerFlag(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public static class Converter extends BaseEnumSetConverter<PlayerFlag> {
+        public Converter() {
+            super(PlayerFlag.class);
+        }
+    }
+}

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/PlayerComponent.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/PlayerComponent.java
@@ -1,6 +1,6 @@
 package com.agonyforge.mud.demo.model.impl;
 
-import com.agonyforge.mud.demo.model.constant.PlayerFlag;
+import com.agonyforge.mud.demo.model.constant.AdminFlag;
 import jakarta.persistence.*;
 
 import java.util.EnumSet;
@@ -17,8 +17,8 @@ public class PlayerComponent extends Persistent {
     private String webSocketSession;
     private String title;
 
-    @Convert(converter = PlayerFlag.Converter.class)
-    private EnumSet<PlayerFlag> adminFlags = EnumSet.noneOf(PlayerFlag.class);
+    @Convert(converter = AdminFlag.Converter.class)
+    private EnumSet<AdminFlag> adminFlags = EnumSet.noneOf(AdminFlag.class);
 
     @ManyToMany()
     private Set<Role> roles = new HashSet<>();
@@ -55,11 +55,11 @@ public class PlayerComponent extends Persistent {
         this.title = title;
     }
 
-    public EnumSet<PlayerFlag> getAdminFlags() {
+    public EnumSet<AdminFlag> getAdminFlags() {
         return adminFlags;
     }
 
-    public void setAdminFlags(EnumSet<PlayerFlag> flags) {
+    public void setAdminFlags(EnumSet<AdminFlag> flags) {
         this.adminFlags = flags;
     }
 

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/PlayerComponent.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/PlayerComponent.java
@@ -1,7 +1,9 @@
 package com.agonyforge.mud.demo.model.impl;
 
+import com.agonyforge.mud.demo.model.constant.PlayerFlag;
 import jakarta.persistence.*;
 
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -14,6 +16,9 @@ public class PlayerComponent extends Persistent {
     private String username;
     private String webSocketSession;
     private String title;
+
+    @Convert(converter = PlayerFlag.Converter.class)
+    private EnumSet<PlayerFlag> flags = EnumSet.noneOf(PlayerFlag.class);
 
     @ManyToMany()
     private Set<Role> roles = new HashSet<>();
@@ -48,6 +53,14 @@ public class PlayerComponent extends Persistent {
 
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    public EnumSet<PlayerFlag> getFlags() {
+        return flags;
+    }
+
+    public void setFlags(EnumSet<PlayerFlag> flags) {
+        this.flags = flags;
     }
 
     public Set<Role> getRoles() {

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/PlayerComponent.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/PlayerComponent.java
@@ -18,7 +18,7 @@ public class PlayerComponent extends Persistent {
     private String title;
 
     @Convert(converter = PlayerFlag.Converter.class)
-    private EnumSet<PlayerFlag> flags = EnumSet.noneOf(PlayerFlag.class);
+    private EnumSet<PlayerFlag> adminFlags = EnumSet.noneOf(PlayerFlag.class);
 
     @ManyToMany()
     private Set<Role> roles = new HashSet<>();
@@ -55,12 +55,12 @@ public class PlayerComponent extends Persistent {
         this.title = title;
     }
 
-    public EnumSet<PlayerFlag> getFlags() {
-        return flags;
+    public EnumSet<PlayerFlag> getAdminFlags() {
+        return adminFlags;
     }
 
-    public void setFlags(EnumSet<PlayerFlag> flags) {
-        this.flags = flags;
+    public void setAdminFlags(EnumSet<PlayerFlag> flags) {
+        this.adminFlags = flags;
     }
 
     public Set<Role> getRoles() {

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/LookCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/LookCommandTest.java
@@ -136,10 +136,7 @@ public class LookCommandTest {
         when(target.getCharacter()).thenReturn(targetCharacterComponent);
         when(target.getCharacter().getName()).thenReturn("Target");
         when(item.getItem()).thenReturn(itemComponent);
-        when(item.getTemplate()).thenReturn(itemProto);
-        when(item.getTemplate().getId()).thenReturn(100L);
         when(itemComponent.getLongDescription()).thenReturn("A test is zipping wildly around the room.");
-        when(room.getId()).thenReturn(roomId);
         when(room.getName()).thenReturn("Test Room");
         when(room.getDescription()).thenReturn("This room is a test.");
         when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
@@ -157,7 +154,7 @@ public class LookCommandTest {
             output);
 
         assertEquals(question, result);
-        assertTrue(output.getOutput().get(0).contains("(100) Test Room"));
+        assertTrue(output.getOutput().get(0).contains("Test Room"));
         assertTrue(output.getOutput().get(1).contains("This room is a test."));
         assertTrue(output.getOutput().get(2).contains("Exits:"));
         assertTrue(output.getOutput().get(3).contains("Target is here."));

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/TeleportCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/TeleportCommandTest.java
@@ -6,6 +6,7 @@ import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.AdminFlag;
 import com.agonyforge.mud.demo.model.constant.Pronoun;
 import com.agonyforge.mud.demo.model.impl.*;
 import com.agonyforge.mud.demo.model.repository.MudCharacterRepository;
@@ -19,10 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationContext;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Random;
+import java.util.*;
 
 import static com.agonyforge.mud.core.config.SessionConfiguration.MUD_CHARACTER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -96,6 +94,7 @@ public class TeleportCommandTest {
         lenient().when(ch.getCharacter()).thenReturn(chCharacter);
         lenient().when(chCharacter.getName()).thenReturn("Scion");
         lenient().when(ch.getPlayer()).thenReturn(chPlayer);
+        lenient().when(chPlayer.getAdminFlags()).thenReturn(EnumSet.noneOf(AdminFlag.class));
 
         lenient().when(mudCharacterRepository.findById(eq(targetId))).thenReturn(Optional.of(target));
         lenient().when(target.getLocation()).thenReturn(targetLocation);
@@ -103,7 +102,8 @@ public class TeleportCommandTest {
         lenient().when(target.getCharacter()).thenReturn(targetCharacter);
         lenient().when(targetCharacter.getName()).thenReturn("Target");
         lenient().when(targetCharacter.getPronoun()).thenReturn(Pronoun.THEY);
-        lenient().when(target.getPlayer()).thenReturn(chPlayer);
+        lenient().when(target.getPlayer()).thenReturn(targetPlayer);
+        lenient().when(targetPlayer.getAdminFlags()).thenReturn(EnumSet.noneOf(AdminFlag.class));
     }
 
     @Test

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/TransferCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/TransferCommandTest.java
@@ -6,6 +6,7 @@ import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.AdminFlag;
 import com.agonyforge.mud.demo.model.constant.Pronoun;
 import com.agonyforge.mud.demo.model.impl.*;
 import com.agonyforge.mud.demo.model.repository.MudCharacterRepository;
@@ -19,10 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationContext;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Random;
+import java.util.*;
 
 import static com.agonyforge.mud.core.config.SessionConfiguration.MUD_CHARACTER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -96,6 +94,7 @@ public class TransferCommandTest {
         lenient().when(ch.getCharacter()).thenReturn(chCharacter);
         lenient().when(chCharacter.getName()).thenReturn("Scion");
         lenient().when(ch.getPlayer()).thenReturn(chPlayer);
+        lenient().when(chPlayer.getAdminFlags()).thenReturn(EnumSet.noneOf(AdminFlag.class));
 
         lenient().when(mudCharacterRepository.findById(eq(targetId))).thenReturn(Optional.of(target));
         lenient().when(target.getLocation()).thenReturn(targetLocation);
@@ -103,7 +102,8 @@ public class TransferCommandTest {
         lenient().when(target.getCharacter()).thenReturn(targetCharacter);
         lenient().when(targetCharacter.getName()).thenReturn("Target");
         lenient().when(targetCharacter.getPronoun()).thenReturn(Pronoun.THEY);
-        lenient().when(target.getPlayer()).thenReturn(chPlayer);
+        lenient().when(target.getPlayer()).thenReturn(targetPlayer);
+        lenient().when(targetPlayer.getAdminFlags()).thenReturn(EnumSet.noneOf(AdminFlag.class));
     }
 
     @Test

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/login/CharacterViewQuestionTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/login/CharacterViewQuestionTest.java
@@ -7,6 +7,7 @@ import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.AdminFlag;
 import com.agonyforge.mud.demo.model.impl.*;
 import com.agonyforge.mud.demo.model.constant.Pronoun;
 import com.agonyforge.mud.demo.model.repository.*;
@@ -180,6 +181,7 @@ public class CharacterViewQuestionTest {
         when(wsContext.getAttributes()).thenReturn(attributes);
         when(wsContext.getSessionId()).thenReturn(wsSessionId);
 
+        when(playerComponent.getAdminFlags()).thenReturn(EnumSet.noneOf(AdminFlag.class));
         when(ch.getPlayer()).thenReturn(playerComponent);
         when(ch.getCharacter()).thenReturn(characterComponent);
         when(ch.getLocation())
@@ -221,6 +223,7 @@ public class CharacterViewQuestionTest {
         when(wsContext.getAttributes()).thenReturn(attributes);
         when(wsContext.getSessionId()).thenReturn(wsSessionId);
 
+        when(playerComponent.getAdminFlags()).thenReturn(EnumSet.noneOf(AdminFlag.class));
         when(ch.getPlayer()).thenReturn(playerComponent);
         when(ch.getLocation()).thenReturn(locationComponent);
         when(ch.getCharacter()).thenReturn(characterComponent);


### PR DESCRIPTION
Adds an `AdminFlag` enum for configuration flags.
Adds a `CONFIG` command for toggling admin flags.
Adds a HOLYLIGHT flag to the `AdminFlag` enum.
Adds logic in the LOOK command to show or not show ID numbers for rooms, items and characters based on whether the viewer has the HOLYLIGHT flag enabled.