### PR TITLE
feat: implement "force" command for #411

### DIFF
--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/ForceCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/ForceCommand.java
@@ -1,0 +1,82 @@
+package com.agonyforge.mud.demo.cli.command;
+
+import com.agonyforge.mud.core.cli.Question;
+import com.agonyforge.mud.core.web.model.Input;
+import com.agonyforge.mud.core.web.model.Output;
+import com.agonyforge.mud.core.web.model.WebSocketContext;
+import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.impl.MudCharacter;
+import com.agonyforge.mud.demo.service.CommService;
+
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+@Component("forceCommand")
+public class ForceCommand extends AbstractCommand {
+    private static final Logger LOGGER = (Logger) LoggerFactory.getLogger(ForceCommand.class);
+
+    @Autowired
+    public ForceCommand(RepositoryBundle repositoryBundle,
+            CommService commService,
+            ApplicationContext applicationContext) {
+        super(repositoryBundle, commService, applicationContext);
+    }
+
+    @Override
+    public Question execute(Question question,
+            WebSocketContext webSocketContext,
+            List<String> tokens,
+            Input input,
+            Output output) {
+
+        if (tokens.size() == 1) {
+            output.append("[default]Who would you like to force to?");
+            return question;
+        }
+
+        if (tokens.size() == 2) {
+            output.append("[default]What would you like to force them to do?");
+            return question;
+        }
+
+        // Get the target player name and command to force
+        String targetName = tokens.get(1);
+        String forcedCommand = input.getInput().replaceFirst("(?i)force\\s+" + targetName + "\\s+", "").trim();
+
+        // Get current character
+        MudCharacter ch = getCurrentCharacter(webSocketContext, output);
+
+        // Find the target character (search in current room first, then globally)
+        Optional<MudCharacter> targetOptional = findRoomCharacter(ch, targetName);
+
+        if (targetOptional.isEmpty()) {
+            targetOptional = findWorldCharacter(ch, targetName);
+        }
+
+        if (targetOptional.isEmpty()) {
+            output.append("[default]There isn't anyone by that name.");
+            return question;
+        }
+
+        MudCharacter target = targetOptional.get();
+
+        // Send the notification
+        output.append("[yellow]You force %s to: %s",
+                target.getCharacter().getName(),
+                forcedCommand);
+
+        getCommService().sendTo(target,
+                new Output("[red]%s FORCES you to: %s", ch.getPlayer().getUsername(), forcedCommand));
+
+        // Execute the command using existing input pipeline
+        getCommService().executeCommandAs(webSocketContext, target, forcedCommand);
+
+        return question;
+    }
+}

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/ForceCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/ForceCommand.java
@@ -1,6 +1,7 @@
 package com.agonyforge.mud.demo.cli.command;
 
 import com.agonyforge.mud.core.cli.Question;
+import com.agonyforge.mud.core.cli.Tokenizer;
 import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
@@ -16,24 +17,25 @@ import java.util.Optional;
 
 @Component("forceCommand")
 public class ForceCommand extends AbstractCommand {
+    private final ApplicationContext applicationContext;
+
     @Autowired
     public ForceCommand(
-        RepositoryBundle repositoryBundle,
-        CommService commService,
-        ApplicationContext applicationContext
-    ) {
+            RepositoryBundle repositoryBundle,
+            CommService commService,
+            ApplicationContext applicationContext) {
         super(repositoryBundle, commService, applicationContext);
+        this.applicationContext = applicationContext;
     }
 
     @Override
     public Question execute(
-        Question question,
-        WebSocketContext webSocketContext,
-        List<String> tokens,
-        Input input,
-        Output output
-    ) {
-        // Validate arguments
+            Question question,
+            WebSocketContext webSocketContext,
+            List<String> tokens,
+            Input input,
+            Output output) {
+        // Validate argument count
         if (tokens.size() == 1) {
             output.append("[default]Who would you like to force?");
             return question;
@@ -43,11 +45,36 @@ public class ForceCommand extends AbstractCommand {
             return question;
         }
 
-        // Parse target name and forced command
+        // Parse target name and forced command text
         String targetName = tokens.get(1);
         String forcedCommand = input.getInput()
-            .replaceFirst("(?i)force\\s+" + targetName + "\\s+", "")
-            .trim();
+                .replaceFirst("(?i)force\\s+" + targetName + "\\s+", "")
+                .trim();
+
+        // Check that the forced command exists as a bean
+        String[] parts = forcedCommand.split("\\s+");
+        String cmdName = parts[0].toLowerCase();
+        String beanName = cmdName + "Command";
+        if (!applicationContext.containsBean(beanName)) {
+            output.append("[default]That command does not exist: %s", cmdName);
+            return question;
+        }
+
+        // Validate forced command arguments by dry-running the command
+        List<String> forcedTokens = Tokenizer.tokenize(forcedCommand);
+        @SuppressWarnings("unchecked")
+        com.agonyforge.mud.demo.cli.command.Command cmdBean = (com.agonyforge.mud.demo.cli.command.Command) applicationContext
+                .getBean(beanName);
+
+        Output validationOutput = new Output();
+        Question cmdQuestion = applicationContext.getBean("commandQuestion", Question.class);
+        cmdBean.execute(cmdQuestion, webSocketContext, forcedTokens, new Input(forcedCommand), validationOutput);
+
+        String validationText = validationOutput.toString();
+        if (validationText.startsWith("[default]")) {
+            output.append(validationText);
+            return question;
+        }
 
         // Lookup executor and target characters
         MudCharacter executor = getCurrentCharacter(webSocketContext, output);
@@ -63,20 +90,17 @@ public class ForceCommand extends AbstractCommand {
 
         // Notify executor
         output.append(
-            "[yellow]You force %s to: %s",
-            target.getCharacter().getName(),
-            forcedCommand
-        );
+                "[yellow]You force %s to: %s",
+                target.getCharacter().getName(),
+                forcedCommand);
 
         // Notify target
         getCommService().sendTo(
-            target,
-            new Output(
-                "[red]%s FORCES you to: %s",
-                executor.getCharacter().getName(),
-                forcedCommand
-            )
-        );
+                target,
+                new Output(
+                        "[red]%s FORCES you to: %s",
+                        executor.getCharacter().getName(),
+                        forcedCommand));
 
         // Execute the forced command as the target
         getCommService().executeCommandAs(webSocketContext, target, forcedCommand);

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/ForceCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/ForceCommand.java
@@ -7,74 +7,78 @@ import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
 import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import com.agonyforge.mud.demo.service.CommService;
-
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.logging.Logger;
 
 @Component("forceCommand")
 public class ForceCommand extends AbstractCommand {
-    private static final Logger LOGGER = (Logger) LoggerFactory.getLogger(ForceCommand.class);
-
     @Autowired
-    public ForceCommand(RepositoryBundle repositoryBundle,
-            CommService commService,
-            ApplicationContext applicationContext) {
+    public ForceCommand(
+        RepositoryBundle repositoryBundle,
+        CommService commService,
+        ApplicationContext applicationContext
+    ) {
         super(repositoryBundle, commService, applicationContext);
     }
 
     @Override
-    public Question execute(Question question,
-            WebSocketContext webSocketContext,
-            List<String> tokens,
-            Input input,
-            Output output) {
-
+    public Question execute(
+        Question question,
+        WebSocketContext webSocketContext,
+        List<String> tokens,
+        Input input,
+        Output output
+    ) {
+        // Validate arguments
         if (tokens.size() == 1) {
-            output.append("[default]Who would you like to force to?");
+            output.append("[default]Who would you like to force?");
             return question;
         }
-
         if (tokens.size() == 2) {
             output.append("[default]What would you like to force them to do?");
             return question;
         }
 
-        // Get the target player name and command to force
+        // Parse target name and forced command
         String targetName = tokens.get(1);
-        String forcedCommand = input.getInput().replaceFirst("(?i)force\\s+" + targetName + "\\s+", "").trim();
+        String forcedCommand = input.getInput()
+            .replaceFirst("(?i)force\\s+" + targetName + "\\s+", "")
+            .trim();
 
-        // Get current character
-        MudCharacter ch = getCurrentCharacter(webSocketContext, output);
-
-        // Find the target character (search in current room first, then globally)
-        Optional<MudCharacter> targetOptional = findRoomCharacter(ch, targetName);
-
-        if (targetOptional.isEmpty()) {
-            targetOptional = findWorldCharacter(ch, targetName);
+        // Lookup executor and target characters
+        MudCharacter executor = getCurrentCharacter(webSocketContext, output);
+        Optional<MudCharacter> targetOpt = findRoomCharacter(executor, targetName);
+        if (targetOpt.isEmpty()) {
+            targetOpt = findWorldCharacter(executor, targetName);
         }
-
-        if (targetOptional.isEmpty()) {
+        if (targetOpt.isEmpty()) {
             output.append("[default]There isn't anyone by that name.");
             return question;
         }
+        MudCharacter target = targetOpt.get();
 
-        MudCharacter target = targetOptional.get();
+        // Notify executor
+        output.append(
+            "[yellow]You force %s to: %s",
+            target.getCharacter().getName(),
+            forcedCommand
+        );
 
-        // Send the notification
-        output.append("[yellow]You force %s to: %s",
-                target.getCharacter().getName(),
-                forcedCommand);
+        // Notify target
+        getCommService().sendTo(
+            target,
+            new Output(
+                "[red]%s FORCES you to: %s",
+                executor.getCharacter().getName(),
+                forcedCommand
+            )
+        );
 
-        getCommService().sendTo(target,
-                new Output("[red]%s FORCES you to: %s", ch.getPlayer().getUsername(), forcedCommand));
-
-        // Execute the command using existing input pipeline
+        // Execute the forced command as the target
         getCommService().executeCommandAs(webSocketContext, target, forcedCommand);
 
         return question;

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
@@ -41,14 +41,10 @@ public class CommandLoader {
                         refs.put("UP", new CommandReference(1, "UP", "upCommand", "Move up."));
                         refs.put("DOWN", new CommandReference(1, "DOWN", "downCommand", "Move down."));
 
-                        refs.put("NORTHEAST",
-                                        new CommandReference(2, "NORTHEAST", "northeastCommand", "Move northeast."));
-                        refs.put("NORTHWEST",
-                                        new CommandReference(2, "NORTHWEST", "northwestCommand", "Move northwest."));
-                        refs.put("SOUTHEAST",
-                                        new CommandReference(2, "SOUTHEAST", "southeastCommand", "Move southeast."));
-                        refs.put("SOUTHWEST",
-                                        new CommandReference(2, "SOUTHWEST", "southwestCommand", "Move southwest."));
+                        refs.put("NORTHEAST", new CommandReference(2, "NORTHEAST", "northeastCommand", "Move northeast."));
+                        refs.put("NORTHWEST", new CommandReference(2, "NORTHWEST", "northwestCommand", "Move northwest."));
+                        refs.put("SOUTHEAST", new CommandReference(2, "SOUTHEAST", "southeastCommand", "Move southeast."));
+                        refs.put("SOUTHWEST", new CommandReference(2, "SOUTHWEST", "southwestCommand", "Move southwest."));
                         refs.put("NE", new CommandReference(2, "NE", "northeastCommand", "Move northeast."));
                         refs.put("NW", new CommandReference(2, "NW", "northwestCommand", "Move northwest."));
                         refs.put("SE", new CommandReference(2, "SE", "southeastCommand", "Move southeast."));
@@ -56,68 +52,45 @@ public class CommandLoader {
 
                         refs.put("HELP", new CommandReference(4, "HELP", "helpCommand", "Get help with commands."));
 
-                        refs.put("LOOK", new CommandReference(5, "LOOK", "lookCommand",
-                                        "Look at things in the world."));
+                        refs.put("LOOK", new CommandReference(5, "LOOK", "lookCommand", "Look at things in the world."));
                         refs.put("WHO", new CommandReference(5, "WHO", "whoCommand", "See who is playing."));
-                        refs.put("SCORE",
-                                        new CommandReference(5, "SCORE", "scoreCommand", "See your character sheet."));
-                        refs.put("EQUIPMENT", new CommandReference(5, "EQUIPMENT", "equipmentCommand",
-                                        "See what you're wearing."));
-                        refs.put("INVENTORY",
-                                        new CommandReference(5, "INVENTORY", "inventoryCommand",
-                                                        "See what you're carrying."));
-                        refs.put("TITLE",
-                                        new CommandReference(5, "TITLE", "titleCommand",
-                                                        "Change your title message on the who list."));
+                        refs.put("SCORE", new CommandReference(5, "SCORE", "scoreCommand", "See your character sheet."));
+                        refs.put("EQUIPMENT", new CommandReference(5, "EQUIPMENT", "equipmentCommand", "See what you're wearing."));
+                        refs.put("INVENTORY", new CommandReference(5, "INVENTORY", "inventoryCommand", "See what you're carrying."));
+                        refs.put("TITLE", new CommandReference(5, "TITLE", "titleCommand","Change your title message on the who list."));
 
                         refs.put("DROP", new CommandReference(10, "DROP", "dropCommand", "Drop an item."));
                         refs.put("GET", new CommandReference(10, "GET", "getCommand", "Pick up an item."));
                         refs.put("GIVE", new CommandReference(10, "GIVE", "giveCommand", "Give an item to someone."));
-                        refs.put("REMOVE",
-                                        new CommandReference(10, "REMOVE", "removeCommand", "Stop wearing an item."));
-                        refs.put("WEAR", new CommandReference(10, "WEAR", "wearCommand",
-                                        "Wear an item that you're carrying."));
-                        refs.put("EMOTE",
-                                        new CommandReference(10, "EMOTE", "emoteCommand", "Perform a social action."));
-                        refs.put("GOSSIP", new CommandReference(10, "GOSSIP", "gossipCommand",
-                                        "Talk on the worldwide channel."));
+                        refs.put("REMOVE", new CommandReference(10, "REMOVE", "removeCommand", "Stop wearing an item."));
+                        refs.put("WEAR", new CommandReference(10, "WEAR", "wearCommand","Wear an item that you're carrying."));
+                        refs.put("EMOTE", new CommandReference(10, "EMOTE", "emoteCommand", "Perform a social action."));
+                        refs.put("GOSSIP", new CommandReference(10, "GOSSIP", "gossipCommand","Talk on the worldwide channel."));
                         refs.put("SAY", new CommandReference(10, "SAY", "sayCommand", "Talk in the room you're in."));
-                        refs.put("SHOUT", new CommandReference(10, "SHOUT", "shoutCommand",
-                                        "Talk in the area you're in."));
-                        refs.put("TELL", new CommandReference(10, "TELL", "tellCommand",
-                                        "Say something privately to someone anywhere in the world."));
-                        refs.put("WHISPER", new CommandReference(10, "WHISPER", "whisperCommand",
-                                        "Say something privately to someone in the same room."));
+                        refs.put("SHOUT", new CommandReference(10, "SHOUT", "shoutCommand","Talk in the area you're in."));
+                        refs.put("TELL", new CommandReference(10, "TELL", "tellCommand","Say something privately to someone anywhere in the world."));
+                        refs.put("WHISPER", new CommandReference(10, "WHISPER", "whisperCommand","Say something privately to someone in the same room."));
                         refs.put("HIT", new CommandReference(10, "HIT", "hitCommand", "Try to hit someone."));
                         refs.put("KILL", new CommandReference(10, "KILL", "hitCommand", "Try to kill someone."));
 
-                        refs.put("ROLL", new CommandReference(15, "ROLL", "rollCommand", "Roll some dice."));
-                        refs.put("TIME", new CommandReference(15, "TIME", "timeCommand", "See what time it is."));
-                        refs.put("QUIT", new CommandReference(15, "QUIT", "quitCommand",
-                                        "Return to the character menu."));
+                        refs.put("ROLL", new CommandReference(15, "ROLL", "rollCommand","Roll some dice."));
+                        refs.put("TIME", new CommandReference(15, "TIME", "timeCommand","See what time it is."));
+                        refs.put("QUIT", new CommandReference(15, "QUIT", "quitCommand","Return to the character menu."));
 
                         refs.put("REDIT", new CommandReference(20, "REDIT", "roomEditorCommand", "Edit a room."));
                         refs.put("IEDIT", new CommandReference(20, "IEDIT", "itemEditorCommand", "Edit an item."));
-                        refs.put("MEDIT", new CommandReference(20, "MEDIT", "nonPlayerCreatureEditorCommand",
-                                        "Edit a creature."));
+                        refs.put("MEDIT", new CommandReference(20, "MEDIT", "nonPlayerCreatureEditorCommand","Edit a creature."));
                         refs.put("CEDIT", new CommandReference(20, "CEDIT", "commandEditorCommand", "Edit commands."));
 
-                        refs.put("CONFIG", new CommandReference(30, "CONFIG", "configCommand",
-                                        "Configure admin preferences."));
+                        refs.put("CONFIG", new CommandReference(30, "CONFIG", "configCommand","Configure admin preferences."));
                         refs.put("GOTO", new CommandReference(30, "GOTO", "gotoCommand", "Go to a room or player."));
-                        refs.put("TRANSFER", new CommandReference(30, "TRANSFER", "transferCommand",
-                                        "Bring a player to you."));
-                        refs.put("TELEPORT", new CommandReference(30, "TELEPORT", "teleportCommand",
-                                        "Send a player to a room."));
+                        refs.put("TRANSFER", new CommandReference(30, "TRANSFER", "transferCommand", "Bring a player to you."));
+                        refs.put("TELEPORT", new CommandReference(30, "TELEPORT", "teleportCommand", "Send a player to a room."));
                         refs.put("CREATE", new CommandReference(30, "CREATE", "createCommand", "Create an item."));
                         refs.put("SPAWN", new CommandReference(30, "SPAWN", "spawnCommand", "Spawn a character."));
                         refs.put("PURGE", new CommandReference(30, "PURGE", "purgeCommand", "Destroy an item."));
                         refs.put("SLAY", new CommandReference(30, "SLAY", "slayCommand", "Slay a character."));
-
-                        // Add FORCE command
-                        refs.put("FORCE",
-                                        new CommandReference(30, "FORCE", "forceCommand",
-                                                        "Force another player to execute a command."));
+                        refs.put("FORCE", new CommandReference(30, "FORCE", "forceCommand", "Force another player to execute a command."));
 
                         LOGGER.info("Creating command references");
                         commandRepository.saveAll(refs.values());
@@ -142,8 +115,6 @@ public class CommandLoader {
                         for (String cmd : playerCommands) {
                                 player.getCommands().add(refs.get(cmd));
                         }
-
-                        implementor.getCommands().add(refs.get("FORCE"));
 
                         roleRepository.saveAll(List.of(implementor, player));
                 }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
@@ -90,6 +90,9 @@ public class CommandLoader {
             refs.put("PURGE", new CommandReference(30, "PURGE", "purgeCommand", "Destroy an item."));
             refs.put("SLAY", new CommandReference(30, "SLAY", "slayCommand", "Slay a character."));
 
+            //Add FORCE command
+            refs.put("FORCE", new CommandReference(30, "FORCE","forceCommand","Force another player to execute a command."));
+
             LOGGER.info("Creating command references");
             commandRepository.saveAll(refs.values());
 
@@ -139,6 +142,9 @@ public class CommandLoader {
             player.getCommands().add(refs.get("WHISPER"));
 
             player.getCommands().add(refs.get("TIME"));
+
+            //Adding FORCE to player role
+            player.getCommands().add(refs.get("FORCE"));
 
             roleRepository.saveAll(List.of(implementor, player));
         }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/config/CommandLoader.java
@@ -1,152 +1,151 @@
 package com.agonyforge.mud.demo.config;
 
-import com.agonyforge.mud.demo.model.impl.CommandReference;
-import com.agonyforge.mud.demo.model.impl.Role;
-import com.agonyforge.mud.demo.model.repository.CommandRepository;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import com.agonyforge.mud.demo.model.repository.RoleRepository;
+import javax.annotation.PostConstruct;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.agonyforge.mud.demo.model.impl.CommandReference;
+import com.agonyforge.mud.demo.model.impl.Role;
+import com.agonyforge.mud.demo.model.repository.CommandRepository;
+import com.agonyforge.mud.demo.model.repository.RoleRepository;
 
 @Component
 public class CommandLoader {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CommandLoader.class);
+        private static final Logger LOGGER = LoggerFactory.getLogger(CommandLoader.class);
 
-    private final CommandRepository commandRepository;
-    private final RoleRepository roleRepository;
+        private final CommandRepository commandRepository;
+        private final RoleRepository roleRepository;
 
-    @Autowired
-    public CommandLoader(CommandRepository commandRepository, RoleRepository roleRepository) {
-        this.commandRepository = commandRepository;
-        this.roleRepository = roleRepository;
-    }
-
-    @PostConstruct
-    public void loadCommands() {
-        if (commandRepository.findAll().isEmpty()) {
-            Map<String, CommandReference> refs = new HashMap<>();
-
-            refs.put("NORTH", new CommandReference(1, "NORTH", "northCommand", "Move north."));
-            refs.put("EAST", new CommandReference(1, "EAST", "eastCommand", "Move east."));
-            refs.put("SOUTH", new CommandReference(1, "SOUTH", "southCommand", "Move south."));
-            refs.put("WEST", new CommandReference(1, "WEST", "westCommand", "Move west."));
-            refs.put("UP", new CommandReference(1, "UP", "upCommand", "Move up."));
-            refs.put("DOWN", new CommandReference(1, "DOWN", "downCommand", "Move down."));
-
-            refs.put("NORTHEAST", new CommandReference(2, "NORTHEAST", "northeastCommand", "Move northeast."));
-            refs.put("NORTHWEST", new CommandReference(2, "NORTHWEST", "northwestCommand", "Move northwest."));
-            refs.put("SOUTHEAST", new CommandReference(2, "SOUTHEAST", "southeastCommand", "Move southeast."));
-            refs.put("SOUTHWEST", new CommandReference(2, "SOUTHWEST", "southwestCommand", "Move southwest."));
-            refs.put("NE", new CommandReference(2, "NE", "northeastCommand", "Move northeast."));
-            refs.put("NW", new CommandReference(2, "NW", "northwestCommand", "Move northwest."));
-            refs.put("SE", new CommandReference(2, "SE", "southeastCommand", "Move southeast."));
-            refs.put("SW", new CommandReference(2, "SW", "southwestCommand", "Move southwest."));
-
-            refs.put("HELP", new CommandReference(4, "HELP", "helpCommand", "Get help with commands."));
-
-            refs.put("LOOK", new CommandReference(5, "LOOK", "lookCommand", "Look at things in the world."));
-            refs.put("WHO", new CommandReference(5, "WHO", "whoCommand", "See who is playing."));
-            refs.put("SCORE", new CommandReference(5, "SCORE", "scoreCommand", "See your character sheet."));
-            refs.put("EQUIPMENT", new CommandReference(5, "EQUIPMENT", "equipmentCommand", "See what you're wearing."));
-            refs.put("INVENTORY", new CommandReference(5, "INVENTORY", "inventoryCommand", "See what you're carrying."));
-            refs.put("TITLE", new CommandReference(5, "TITLE", "titleCommand", "Change your title message on the who list."));
-
-            refs.put("DROP", new CommandReference(10, "DROP", "dropCommand", "Drop an item."));
-            refs.put("GET", new CommandReference(10, "GET", "getCommand", "Pick up an item."));
-            refs.put("GIVE", new CommandReference(10, "GIVE", "giveCommand", "Give an item to someone."));
-            refs.put("REMOVE", new CommandReference(10, "REMOVE", "removeCommand", "Stop wearing an item."));
-            refs.put("WEAR", new CommandReference(10, "WEAR", "wearCommand", "Wear an item that you're carrying."));
-            refs.put("EMOTE", new CommandReference(10, "EMOTE", "emoteCommand", "Perform a social action."));
-            refs.put("GOSSIP", new CommandReference(10, "GOSSIP", "gossipCommand", "Talk on the worldwide channel."));
-            refs.put("SAY", new CommandReference(10, "SAY", "sayCommand", "Talk in the room you're in."));
-            refs.put("SHOUT", new CommandReference(10, "SHOUT", "shoutCommand", "Talk in the area you're in."));
-            refs.put("TELL", new CommandReference(10, "TELL", "tellCommand", "Say something privately to someone anywhere in the world."));
-            refs.put("WHISPER", new CommandReference(10, "WHISPER", "whisperCommand", "Say something privately to someone in the same room."));
-            refs.put("HIT", new CommandReference(10, "HIT", "hitCommand", "Try to hit someone."));
-            refs.put("KILL", new CommandReference(10, "KILL", "hitCommand", "Try to kill someone."));
-
-            refs.put("ROLL", new CommandReference(15, "ROLL", "rollCommand", "Roll some dice."));
-            refs.put("TIME", new CommandReference(15, "TIME", "timeCommand", "See what time it is."));
-            refs.put("QUIT", new CommandReference(15, "QUIT", "quitCommand", "Return to the character menu."));
-
-            refs.put("REDIT", new CommandReference(20, "REDIT", "roomEditorCommand", "Edit a room."));
-            refs.put("IEDIT", new CommandReference(20, "IEDIT", "itemEditorCommand", "Edit an item."));
-            refs.put("MEDIT", new CommandReference(20, "MEDIT", "nonPlayerCreatureEditorCommand", "Edit a creature."));
-            refs.put("CEDIT", new CommandReference(20, "CEDIT", "commandEditorCommand", "Edit commands."));
-
-            refs.put("CONFIG", new CommandReference(30, "CONFIG", "configCommand", "Configure admin preferences."));
-            refs.put("GOTO", new CommandReference(30, "GOTO", "gotoCommand", "Go to a room or player."));
-            refs.put("TRANSFER", new CommandReference(30, "TRANSFER", "transferCommand", "Bring a player to you."));
-            refs.put("TELEPORT", new CommandReference(30, "TELEPORT", "teleportCommand", "Send a player to a room."));
-            refs.put("CREATE", new CommandReference(30, "CREATE", "createCommand", "Create an item."));
-            refs.put("SPAWN", new CommandReference(30, "SPAWN", "spawnCommand", "Spawn a character."));
-            refs.put("PURGE", new CommandReference(30, "PURGE", "purgeCommand", "Destroy an item."));
-            refs.put("SLAY", new CommandReference(30, "SLAY", "slayCommand", "Slay a character."));
-
-            //Add FORCE command
-            refs.put("FORCE", new CommandReference(30, "FORCE","forceCommand","Force another player to execute a command."));
-
-            LOGGER.info("Creating command references");
-            commandRepository.saveAll(refs.values());
-
-            Role implementor = new Role();
-
-            implementor.setName("Implementor");
-            implementor.setImplementor(true);
-
-            Role player = new Role();
-
-            player.setName("Player");
-            player.getCommands().add(refs.get("NORTH"));
-            player.getCommands().add(refs.get("EAST"));
-            player.getCommands().add(refs.get("SOUTH"));
-            player.getCommands().add(refs.get("WEST"));
-            player.getCommands().add(refs.get("UP"));
-            player.getCommands().add(refs.get("DOWN"));
-
-            player.getCommands().add(refs.get("NORTHEAST"));
-            player.getCommands().add(refs.get("NORTHWEST"));
-            player.getCommands().add(refs.get("SOUTHEAST"));
-            player.getCommands().add(refs.get("SOUTHWEST"));
-            player.getCommands().add(refs.get("NE"));
-            player.getCommands().add(refs.get("NW"));
-            player.getCommands().add(refs.get("SE"));
-            player.getCommands().add(refs.get("SW"));
-
-            player.getCommands().add(refs.get("HELP"));
-            player.getCommands().add(refs.get("LOOK"));
-            player.getCommands().add(refs.get("WHO"));
-            player.getCommands().add(refs.get("SCORE"));
-            player.getCommands().add(refs.get("TITLE"));
-
-            player.getCommands().add(refs.get("EQUIPMENT"));
-            player.getCommands().add(refs.get("INVENTORY"));
-            player.getCommands().add(refs.get("DROP"));
-            player.getCommands().add(refs.get("GET"));
-            player.getCommands().add(refs.get("GIVE"));
-            player.getCommands().add(refs.get("REMOVE"));
-            player.getCommands().add(refs.get("WEAR"));
-
-            player.getCommands().add(refs.get("EMOTE"));
-            player.getCommands().add(refs.get("GOSSIP"));
-            player.getCommands().add(refs.get("SAY"));
-            player.getCommands().add(refs.get("SHOUT"));
-            player.getCommands().add(refs.get("TELL"));
-            player.getCommands().add(refs.get("WHISPER"));
-
-            player.getCommands().add(refs.get("TIME"));
-
-            //Adding FORCE to player role
-            player.getCommands().add(refs.get("FORCE"));
-
-            roleRepository.saveAll(List.of(implementor, player));
+        @Autowired
+        public CommandLoader(CommandRepository commandRepository, RoleRepository roleRepository) {
+                this.commandRepository = commandRepository;
+                this.roleRepository = roleRepository;
         }
-    }
+
+        @PostConstruct
+        public void loadCommands() {
+                if (commandRepository.findAll().isEmpty()) {
+                        Map<String, CommandReference> refs = new HashMap<>();
+
+                        refs.put("NORTH", new CommandReference(1, "NORTH", "northCommand", "Move north."));
+                        refs.put("EAST", new CommandReference(1, "EAST", "eastCommand", "Move east."));
+                        refs.put("SOUTH", new CommandReference(1, "SOUTH", "southCommand", "Move south."));
+                        refs.put("WEST", new CommandReference(1, "WEST", "westCommand", "Move west."));
+                        refs.put("UP", new CommandReference(1, "UP", "upCommand", "Move up."));
+                        refs.put("DOWN", new CommandReference(1, "DOWN", "downCommand", "Move down."));
+
+                        refs.put("NORTHEAST",
+                                        new CommandReference(2, "NORTHEAST", "northeastCommand", "Move northeast."));
+                        refs.put("NORTHWEST",
+                                        new CommandReference(2, "NORTHWEST", "northwestCommand", "Move northwest."));
+                        refs.put("SOUTHEAST",
+                                        new CommandReference(2, "SOUTHEAST", "southeastCommand", "Move southeast."));
+                        refs.put("SOUTHWEST",
+                                        new CommandReference(2, "SOUTHWEST", "southwestCommand", "Move southwest."));
+                        refs.put("NE", new CommandReference(2, "NE", "northeastCommand", "Move northeast."));
+                        refs.put("NW", new CommandReference(2, "NW", "northwestCommand", "Move northwest."));
+                        refs.put("SE", new CommandReference(2, "SE", "southeastCommand", "Move southeast."));
+                        refs.put("SW", new CommandReference(2, "SW", "southwestCommand", "Move southwest."));
+
+                        refs.put("HELP", new CommandReference(4, "HELP", "helpCommand", "Get help with commands."));
+
+                        refs.put("LOOK", new CommandReference(5, "LOOK", "lookCommand",
+                                        "Look at things in the world."));
+                        refs.put("WHO", new CommandReference(5, "WHO", "whoCommand", "See who is playing."));
+                        refs.put("SCORE",
+                                        new CommandReference(5, "SCORE", "scoreCommand", "See your character sheet."));
+                        refs.put("EQUIPMENT", new CommandReference(5, "EQUIPMENT", "equipmentCommand",
+                                        "See what you're wearing."));
+                        refs.put("INVENTORY",
+                                        new CommandReference(5, "INVENTORY", "inventoryCommand",
+                                                        "See what you're carrying."));
+                        refs.put("TITLE",
+                                        new CommandReference(5, "TITLE", "titleCommand",
+                                                        "Change your title message on the who list."));
+
+                        refs.put("DROP", new CommandReference(10, "DROP", "dropCommand", "Drop an item."));
+                        refs.put("GET", new CommandReference(10, "GET", "getCommand", "Pick up an item."));
+                        refs.put("GIVE", new CommandReference(10, "GIVE", "giveCommand", "Give an item to someone."));
+                        refs.put("REMOVE",
+                                        new CommandReference(10, "REMOVE", "removeCommand", "Stop wearing an item."));
+                        refs.put("WEAR", new CommandReference(10, "WEAR", "wearCommand",
+                                        "Wear an item that you're carrying."));
+                        refs.put("EMOTE",
+                                        new CommandReference(10, "EMOTE", "emoteCommand", "Perform a social action."));
+                        refs.put("GOSSIP", new CommandReference(10, "GOSSIP", "gossipCommand",
+                                        "Talk on the worldwide channel."));
+                        refs.put("SAY", new CommandReference(10, "SAY", "sayCommand", "Talk in the room you're in."));
+                        refs.put("SHOUT", new CommandReference(10, "SHOUT", "shoutCommand",
+                                        "Talk in the area you're in."));
+                        refs.put("TELL", new CommandReference(10, "TELL", "tellCommand",
+                                        "Say something privately to someone anywhere in the world."));
+                        refs.put("WHISPER", new CommandReference(10, "WHISPER", "whisperCommand",
+                                        "Say something privately to someone in the same room."));
+                        refs.put("HIT", new CommandReference(10, "HIT", "hitCommand", "Try to hit someone."));
+                        refs.put("KILL", new CommandReference(10, "KILL", "hitCommand", "Try to kill someone."));
+
+                        refs.put("ROLL", new CommandReference(15, "ROLL", "rollCommand", "Roll some dice."));
+                        refs.put("TIME", new CommandReference(15, "TIME", "timeCommand", "See what time it is."));
+                        refs.put("QUIT", new CommandReference(15, "QUIT", "quitCommand",
+                                        "Return to the character menu."));
+
+                        refs.put("REDIT", new CommandReference(20, "REDIT", "roomEditorCommand", "Edit a room."));
+                        refs.put("IEDIT", new CommandReference(20, "IEDIT", "itemEditorCommand", "Edit an item."));
+                        refs.put("MEDIT", new CommandReference(20, "MEDIT", "nonPlayerCreatureEditorCommand",
+                                        "Edit a creature."));
+                        refs.put("CEDIT", new CommandReference(20, "CEDIT", "commandEditorCommand", "Edit commands."));
+
+                        refs.put("CONFIG", new CommandReference(30, "CONFIG", "configCommand",
+                                        "Configure admin preferences."));
+                        refs.put("GOTO", new CommandReference(30, "GOTO", "gotoCommand", "Go to a room or player."));
+                        refs.put("TRANSFER", new CommandReference(30, "TRANSFER", "transferCommand",
+                                        "Bring a player to you."));
+                        refs.put("TELEPORT", new CommandReference(30, "TELEPORT", "teleportCommand",
+                                        "Send a player to a room."));
+                        refs.put("CREATE", new CommandReference(30, "CREATE", "createCommand", "Create an item."));
+                        refs.put("SPAWN", new CommandReference(30, "SPAWN", "spawnCommand", "Spawn a character."));
+                        refs.put("PURGE", new CommandReference(30, "PURGE", "purgeCommand", "Destroy an item."));
+                        refs.put("SLAY", new CommandReference(30, "SLAY", "slayCommand", "Slay a character."));
+
+                        // Add FORCE command
+                        refs.put("FORCE",
+                                        new CommandReference(30, "FORCE", "forceCommand",
+                                                        "Force another player to execute a command."));
+
+                        LOGGER.info("Creating command references");
+                        commandRepository.saveAll(refs.values());
+
+                        Role implementor = new Role();
+                        implementor.setName("Implementor");
+                        implementor.setImplementor(true);
+
+                        Role player = new Role();
+                        player.setName("Player");
+
+                        String[] playerCommands = {
+                                        "NORTH", "EAST", "SOUTH", "WEST", "UP", "DOWN",
+                                        "NORTHEAST", "NORTHWEST", "SOUTHEAST", "SOUTHWEST",
+                                        "NE", "NW", "SE", "SW",
+                                        "HELP", "LOOK", "WHO", "SCORE", "TITLE",
+                                        "EQUIPMENT", "INVENTORY", "DROP", "GET", "GIVE",
+                                        "REMOVE", "WEAR", "EMOTE", "GOSSIP", "SAY", "SHOUT",
+                                        "TELL", "WHISPER", "TIME",
+                        };
+
+                        for (String cmd : playerCommands) {
+                                player.getCommands().add(refs.get(cmd));
+                        }
+
+                        implementor.getCommands().add(refs.get("FORCE"));
+
+                        roleRepository.saveAll(List.of(implementor, player));
+                }
+        }
 }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/AbstractMudObject.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/AbstractMudObject.java
@@ -60,4 +60,14 @@ public abstract class AbstractMudObject extends Persistent {
     public void setLocation(LocationComponent location) {
         this.location = location;
     }
+
+    public String getName() {
+        return character != null ? character.getName() : null;
+    }
+
+    public void setName(String name) {
+        if (character != null) {
+            character.setName(name);
+        }
+    }
 }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacter.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacter.java
@@ -1,8 +1,12 @@
 package com.agonyforge.mud.demo.model.impl;
 
-import jakarta.persistence.*;
+import java.util.Objects;
 
-import java.util.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 
 @Entity
 public class MudCharacter extends AbstractMudObject {
@@ -37,13 +41,29 @@ public class MudCharacter extends AbstractMudObject {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof MudCharacter that)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof MudCharacter that))
+            return false;
         return Objects.equals(getId(), that.getId());
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(getId());
+    }
+
+    @Override
+    public String getName() {
+        return super.getName();
+    }
+
+    public boolean isImplementor() {
+        if (getPlayer() == null || getPlayer().getRoles() == null) {
+            return false;
+        }
+
+        return getPlayer().getRoles().stream()
+                .anyMatch(Role::isImplementor);
     }
 }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/service/CommService.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/service/CommService.java
@@ -3,6 +3,7 @@ package com.agonyforge.mud.demo.service;
 import com.agonyforge.mud.core.service.EchoService;
 import com.agonyforge.mud.core.service.SessionAttributeService;
 import com.agonyforge.mud.core.service.StompPrincipal;
+import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.model.constant.RoomFlag;
@@ -25,99 +26,103 @@ public class CommService extends EchoService {
 
     @Autowired
     public CommService(ApplicationContext applicationContext,
-                       SimpMessagingTemplate simpMessagingTemplate,
-                       SimpUserRegistry simpUserRegistry,
-                       SessionAttributeService sessionAttributeService,
-                       MudCharacterRepository characterRepository) {
+            SimpMessagingTemplate simpMessagingTemplate,
+            SimpUserRegistry simpUserRegistry,
+            SessionAttributeService sessionAttributeService,
+            MudCharacterRepository characterRepository) {
         super(applicationContext, simpMessagingTemplate, simpUserRegistry, sessionAttributeService);
 
         this.characterRepository = characterRepository;
     }
 
     /**
-     * Send a message to all characters that are playing except the sender and specifically excluded
+     * Send a message to all characters that are playing except the sender and
+     * specifically excluded
      * characters.
      *
      * @param wsContext The WebSocketContext of the sender.
-     * @param message The message to send.
-     * @param except Don't send to these characters.
+     * @param message   The message to send.
+     * @param except    Don't send to these characters.
      */
-    public void sendToAll(WebSocketContext wsContext, Output message, MudCharacter ... except) {
+    public void sendToAll(WebSocketContext wsContext, Output message, MudCharacter... except) {
         List<MudCharacter> skip = List.of(except);
 
         characterRepository.findAll()
-            .stream()
-            .filter(ch -> ch.getPlayer() != null)
-            .filter(ch -> !wsContext.getSessionId().equals(ch.getPlayer().getWebSocketSession()))
-            .filter(ch -> !skip.contains(ch))
-            .forEach(ch -> sendTo(ch, message));
+                .stream()
+                .filter(ch -> ch.getPlayer() != null)
+                .filter(ch -> !wsContext.getSessionId().equals(ch.getPlayer().getWebSocketSession()))
+                .filter(ch -> !skip.contains(ch))
+                .forEach(ch -> sendTo(ch, message));
     }
 
     /**
      * Send a message to all characters except specifically excluded characters.
      *
      * @param message The message to send.
-     * @param except Don't send to these characters.
+     * @param except  Don't send to these characters.
      */
-    public void sendToAll(Output message, MudCharacter ... except) {
+    public void sendToAll(Output message, MudCharacter... except) {
         List<MudCharacter> skip = List.of(except);
 
         characterRepository.findAll()
-            .stream()
-            .filter(ch -> !skip.contains(ch))
-            .forEach(ch -> sendTo(ch, message));
+                .stream()
+                .filter(ch -> !skip.contains(ch))
+                .forEach(ch -> sendTo(ch, message));
     }
 
     /**
      * Send a message to all characters in rooms without the specified flags.
-     * @param message The message to send.
+     * 
+     * @param message   The message to send.
      * @param roomFlags Don't send if the character's room has all of these flags.
-     * @param except Don't send to these characters.
+     * @param except    Don't send to these characters.
      */
-    public void sendToAllWithoutFlags(Output message, EnumSet<RoomFlag> roomFlags, MudCharacter ... except) {
+    public void sendToAllWithoutFlags(Output message, EnumSet<RoomFlag> roomFlags, MudCharacter... except) {
         List<MudCharacter> skip = List.of(except);
 
         characterRepository.findAll()
-            .stream()
-            .filter(ch -> !skip.contains(ch))
-            .filter(ch -> ch.getLocation() != null && ch.getLocation().getRoom() != null && !ch.getLocation().getRoom().getFlags().containsAll(roomFlags))
-            .forEach(ch -> sendTo(ch, message));
+                .stream()
+                .filter(ch -> !skip.contains(ch))
+                .filter(ch -> ch.getLocation() != null && ch.getLocation().getRoom() != null
+                        && !ch.getLocation().getRoom().getFlags().containsAll(roomFlags))
+                .forEach(ch -> sendTo(ch, message));
     }
 
     /**
      * Send a message to all characters in a Zone.
      *
      * @param wsContext The WebSocketContext of the sender.
-     * @param message The message to send.
-     * @param except Don't send to these characters.
+     * @param message   The message to send.
+     * @param except    Don't send to these characters.
      */
-    public void sendToZone(WebSocketContext wsContext, Long zoneId, Output message, MudCharacter ... except) {
+    public void sendToZone(WebSocketContext wsContext, Long zoneId, Output message, MudCharacter... except) {
         String zoneIdString = zoneId.toString();
         List<MudCharacter> skip = List.of(except);
 
         characterRepository.findByLocationRoomIdBetween(zoneId * 100, zoneId * 100 + 100)
-            .stream()
-            .filter(ch -> ch.getPlayer() != null)
-            .filter(ch -> !wsContext.getSessionId().equals(ch.getPlayer().getWebSocketSession()))
-            .filter(ch -> !skip.contains(ch))
-            .filter(ch -> zoneIdString.equals(ch.getLocation().getRoom().getId().toString().substring(0, zoneIdString.length())))
-            .forEach(ch -> sendTo(ch, message));
+                .stream()
+                .filter(ch -> ch.getPlayer() != null)
+                .filter(ch -> !wsContext.getSessionId().equals(ch.getPlayer().getWebSocketSession()))
+                .filter(ch -> !skip.contains(ch))
+                .filter(ch -> zoneIdString
+                        .equals(ch.getLocation().getRoom().getId().toString().substring(0, zoneIdString.length())))
+                .forEach(ch -> sendTo(ch, message));
     }
 
     /**
      * Send a message to all characters in a Room.
      *
-     * @param roomId The ID of the room to send to.
+     * @param roomId  The ID of the room to send to.
      * @param message The message to send.
-     * @param except Don't send to these characters.
+     * @param except  Don't send to these characters.
      */
-    public void sendToRoom(Long roomId, Output message, MudCharacter ... except) {
+    public void sendToRoom(Long roomId, Output message, MudCharacter... except) {
         List<MudCharacter> skip = List.of(except);
         characterRepository.findByLocationRoomId(roomId)
-            .stream()
-            .filter(ch -> ch.getPlayer() != null)
-            .filter(ch -> !skip.contains(ch))
-            .forEach(ch -> sendTo(ch, message));
+                .stream()
+                .filter(ch -> ch.getPlayer() != null)
+                .filter(ch -> !skip.contains(ch))
+                .forEach(ch -> sendTo(ch, message));
     }
 
     /**
@@ -128,13 +133,13 @@ public class CommService extends EchoService {
      */
     public void sendToTargets(List<MudCharacter> targets, Output message) {
         targets
-            .forEach(ch -> sendTo(ch, message));
+                .forEach(ch -> sendTo(ch, message));
     }
 
     /**
      * Send a message to the provided list of characters.
      *
-     * @param ch The character to send to.
+     * @param ch      The character to send to.
      * @param message The message to send.
      */
     public void sendTo(MudCharacter ch, Output message) {
@@ -142,24 +147,69 @@ public class CommService extends EchoService {
             return;
         }
 
-        Map<String, Object> attributes = sessionAttributeService.getSessionAttributes(ch.getPlayer().getWebSocketSession());
+        Map<String, Object> attributes = sessionAttributeService
+                .getSessionAttributes(ch.getPlayer().getWebSocketSession());
 
         if (!"commandQuestion".equals(attributes.get("MUD.QUESTION"))) {
             return;
         }
 
         WebSocketContext targetWsContext = WebSocketContext.build(
-            new StompPrincipal(ch.getPlayer().getUsername()),
-            ch.getPlayer().getWebSocketSession(),
-            attributes);
+                new StompPrincipal(ch.getPlayer().getUsername()),
+                ch.getPlayer().getWebSocketSession(),
+                attributes);
 
         Output messageWithPrompt = appendPrompt(targetWsContext, message);
         MessageHeaders messageHeaders = buildMessageHeaders(ch.getPlayer().getWebSocketSession());
 
         simpMessagingTemplate.convertAndSendToUser(
-            targetWsContext.getPrincipal().getName(),
-            "/queue/output",
-            messageWithPrompt,
-            messageHeaders);
+                targetWsContext.getPrincipal().getName(),
+                "/queue/output",
+                messageWithPrompt,
+                messageHeaders);
+    }
+
+    /**
+     * Send a command to be executed as the specified character.
+     *
+     * @param wsContext The original WebSocketContext (for maintaining session)
+     * @param target    The character who should execute the command
+     * @param command   The command to execute (including arguments)
+     */
+    public void sendCommand(WebSocketContext wsContext, MudCharacter target, String command) {
+        if (target.getPlayer() == null) {
+            return;
+        }
+
+        // Get the target's session attributes
+        Map<String, Object> attributes = sessionAttributeService
+                .getSessionAttributes(target.getPlayer().getWebSocketSession());
+
+        // Create a new context for the target
+        WebSocketContext targetWsContext = WebSocketContext.build(
+                new StompPrincipal(target.getPlayer().getUsername()),
+                target.getPlayer().getWebSocketSession(),
+                attributes);
+
+        // Send the command to be processed by the command system
+        simpMessagingTemplate.convertAndSendToUser(
+                targetWsContext.getPrincipal().getName(),
+                "/queue/command",
+                command,
+                buildMessageHeaders(target.getPlayer().getWebSocketSession()));
+    }
+
+    public void executeCommandAs(WebSocketContext originalContext, MudCharacter target, String command) {
+        if (target.getPlayer() == null)
+            return;
+
+        Map<String, Object> attributes = sessionAttributeService
+                .getSessionAttributes(target.getPlayer().getWebSocketSession());
+
+        WebSocketContext targContext = WebSocketContext.build(new StompPrincipal(target.getPlayer().getUsername()),
+                target.getPlayer().getWebSocketSession(), attributes);
+
+        simpMessagingTemplate.convertAndSendToUser(targContext.getPrincipal().getName(), "/queue/input",
+                new Input(command), buildMessageHeaders(target.getPlayer().getWebSocketSession()));
     }
 }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/service/CommService.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/service/CommService.java
@@ -1,5 +1,8 @@
 package com.agonyforge.mud.demo.service;
 
+import com.agonyforge.mud.core.cli.Question;
+import com.agonyforge.mud.core.cli.Response;
+import com.agonyforge.mud.core.web.controller.WebSocketContextAware; // ← inject this!
 import com.agonyforge.mud.core.service.EchoService;
 import com.agonyforge.mud.core.service.SessionAttributeService;
 import com.agonyforge.mud.core.service.StompPrincipal;
@@ -20,196 +23,191 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
+import static com.agonyforge.mud.core.config.SessionConfiguration.MUD_QUESTION;
+
 @Component
 public class CommService extends EchoService {
-    private final MudCharacterRepository characterRepository;
+        private final WebSocketContextAware webSocketContextAware;
+        private final MudCharacterRepository characterRepository;
+        private final InputProcessingService inputProcessingService;
 
-    @Autowired
-    public CommService(ApplicationContext applicationContext,
-            SimpMessagingTemplate simpMessagingTemplate,
-            SimpUserRegistry simpUserRegistry,
-            SessionAttributeService sessionAttributeService,
-            MudCharacterRepository characterRepository) {
-        super(applicationContext, simpMessagingTemplate, simpUserRegistry, sessionAttributeService);
-
-        this.characterRepository = characterRepository;
-    }
-
-    /**
-     * Send a message to all characters that are playing except the sender and
-     * specifically excluded
-     * characters.
-     *
-     * @param wsContext The WebSocketContext of the sender.
-     * @param message   The message to send.
-     * @param except    Don't send to these characters.
-     */
-    public void sendToAll(WebSocketContext wsContext, Output message, MudCharacter... except) {
-        List<MudCharacter> skip = List.of(except);
-
-        characterRepository.findAll()
-                .stream()
-                .filter(ch -> ch.getPlayer() != null)
-                .filter(ch -> !wsContext.getSessionId().equals(ch.getPlayer().getWebSocketSession()))
-                .filter(ch -> !skip.contains(ch))
-                .forEach(ch -> sendTo(ch, message));
-    }
-
-    /**
-     * Send a message to all characters except specifically excluded characters.
-     *
-     * @param message The message to send.
-     * @param except  Don't send to these characters.
-     */
-    public void sendToAll(Output message, MudCharacter... except) {
-        List<MudCharacter> skip = List.of(except);
-
-        characterRepository.findAll()
-                .stream()
-                .filter(ch -> !skip.contains(ch))
-                .forEach(ch -> sendTo(ch, message));
-    }
-
-    /**
-     * Send a message to all characters in rooms without the specified flags.
-     * 
-     * @param message   The message to send.
-     * @param roomFlags Don't send if the character's room has all of these flags.
-     * @param except    Don't send to these characters.
-     */
-    public void sendToAllWithoutFlags(Output message, EnumSet<RoomFlag> roomFlags, MudCharacter... except) {
-        List<MudCharacter> skip = List.of(except);
-
-        characterRepository.findAll()
-                .stream()
-                .filter(ch -> !skip.contains(ch))
-                .filter(ch -> ch.getLocation() != null && ch.getLocation().getRoom() != null
-                        && !ch.getLocation().getRoom().getFlags().containsAll(roomFlags))
-                .forEach(ch -> sendTo(ch, message));
-    }
-
-    /**
-     * Send a message to all characters in a Zone.
-     *
-     * @param wsContext The WebSocketContext of the sender.
-     * @param message   The message to send.
-     * @param except    Don't send to these characters.
-     */
-    public void sendToZone(WebSocketContext wsContext, Long zoneId, Output message, MudCharacter... except) {
-        String zoneIdString = zoneId.toString();
-        List<MudCharacter> skip = List.of(except);
-
-        characterRepository.findByLocationRoomIdBetween(zoneId * 100, zoneId * 100 + 100)
-                .stream()
-                .filter(ch -> ch.getPlayer() != null)
-                .filter(ch -> !wsContext.getSessionId().equals(ch.getPlayer().getWebSocketSession()))
-                .filter(ch -> !skip.contains(ch))
-                .filter(ch -> zoneIdString
-                        .equals(ch.getLocation().getRoom().getId().toString().substring(0, zoneIdString.length())))
-                .forEach(ch -> sendTo(ch, message));
-    }
-
-    /**
-     * Send a message to all characters in a Room.
-     *
-     * @param roomId  The ID of the room to send to.
-     * @param message The message to send.
-     * @param except  Don't send to these characters.
-     */
-    public void sendToRoom(Long roomId, Output message, MudCharacter... except) {
-        List<MudCharacter> skip = List.of(except);
-        characterRepository.findByLocationRoomId(roomId)
-                .stream()
-                .filter(ch -> ch.getPlayer() != null)
-                .filter(ch -> !skip.contains(ch))
-                .forEach(ch -> sendTo(ch, message));
-    }
-
-    /**
-     * Send a message to the provided list of characters.
-     *
-     * @param targets The characters to send to.
-     * @param message The message to send.
-     */
-    public void sendToTargets(List<MudCharacter> targets, Output message) {
-        targets
-                .forEach(ch -> sendTo(ch, message));
-    }
-
-    /**
-     * Send a message to the provided list of characters.
-     *
-     * @param ch      The character to send to.
-     * @param message The message to send.
-     */
-    public void sendTo(MudCharacter ch, Output message) {
-        if (ch.getPlayer() == null) {
-            return;
+        @Autowired
+        public CommService(ApplicationContext applicationContext,
+                        SimpMessagingTemplate simpMessagingTemplate,
+                        SimpUserRegistry simpUserRegistry,
+                        SessionAttributeService sessionAttributeService,
+                        WebSocketContextAware webSocketContextAware, // ← here
+                        MudCharacterRepository characterRepository,
+                        InputProcessingService inputProcessingService) {
+                super(applicationContext, simpMessagingTemplate, simpUserRegistry, sessionAttributeService);
+                this.webSocketContextAware = webSocketContextAware;
+                this.characterRepository = characterRepository;
+                this.inputProcessingService = inputProcessingService;
         }
 
-        Map<String, Object> attributes = sessionAttributeService
-                .getSessionAttributes(ch.getPlayer().getWebSocketSession());
+        /**
+         * Send a message to all characters that are playing except the sender and
+         * specifically excluded
+         * characters.
+         *
+         * @param wsContext The WebSocketContext of the sender.
+         * @param message   The message to send.
+         * @param except    Don't send to these characters.
+         */
+        public void sendToAll(WebSocketContext wsContext, Output message, MudCharacter... except) {
+                List<MudCharacter> skip = List.of(except);
 
-        if (!"commandQuestion".equals(attributes.get("MUD.QUESTION"))) {
-            return;
+                characterRepository.findAll()
+                                .stream()
+                                .filter(ch -> ch.getPlayer() != null)
+                                .filter(ch -> !wsContext.getSessionId().equals(ch.getPlayer().getWebSocketSession()))
+                                .filter(ch -> !skip.contains(ch))
+                                .forEach(ch -> sendTo(ch, message));
         }
 
-        WebSocketContext targetWsContext = WebSocketContext.build(
-                new StompPrincipal(ch.getPlayer().getUsername()),
-                ch.getPlayer().getWebSocketSession(),
-                attributes);
+        /**
+         * Send a message to all characters except specifically excluded characters.
+         *
+         * @param message The message to send.
+         * @param except  Don't send to these characters.
+         */
+        public void sendToAll(Output message, MudCharacter... except) {
+                List<MudCharacter> skip = List.of(except);
 
-        Output messageWithPrompt = appendPrompt(targetWsContext, message);
-        MessageHeaders messageHeaders = buildMessageHeaders(ch.getPlayer().getWebSocketSession());
-
-        simpMessagingTemplate.convertAndSendToUser(
-                targetWsContext.getPrincipal().getName(),
-                "/queue/output",
-                messageWithPrompt,
-                messageHeaders);
-    }
-
-    /**
-     * Send a command to be executed as the specified character.
-     *
-     * @param wsContext The original WebSocketContext (for maintaining session)
-     * @param target    The character who should execute the command
-     * @param command   The command to execute (including arguments)
-     */
-    public void sendCommand(WebSocketContext wsContext, MudCharacter target, String command) {
-        if (target.getPlayer() == null) {
-            return;
+                characterRepository.findAll()
+                                .stream()
+                                .filter(ch -> !skip.contains(ch))
+                                .forEach(ch -> sendTo(ch, message));
         }
 
-        // Get the target's session attributes
-        Map<String, Object> attributes = sessionAttributeService
-                .getSessionAttributes(target.getPlayer().getWebSocketSession());
+        /**
+         * Send a message to all characters in rooms without the specified flags.
+         * 
+         * @param message   The message to send.
+         * @param roomFlags Don't send if the character's room has all of these flags.
+         * @param except    Don't send to these characters.
+         */
+        public void sendToAllWithoutFlags(Output message, EnumSet<RoomFlag> roomFlags, MudCharacter... except) {
+                List<MudCharacter> skip = List.of(except);
 
-        // Create a new context for the target
-        WebSocketContext targetWsContext = WebSocketContext.build(
-                new StompPrincipal(target.getPlayer().getUsername()),
-                target.getPlayer().getWebSocketSession(),
-                attributes);
+                characterRepository.findAll()
+                                .stream()
+                                .filter(ch -> !skip.contains(ch))
+                                .filter(ch -> ch.getLocation() != null && ch.getLocation().getRoom() != null
+                                                && !ch.getLocation().getRoom().getFlags().containsAll(roomFlags))
+                                .forEach(ch -> sendTo(ch, message));
+        }
 
-        // Send the command to be processed by the command system
-        simpMessagingTemplate.convertAndSendToUser(
-                targetWsContext.getPrincipal().getName(),
-                "/queue/command",
-                command,
-                buildMessageHeaders(target.getPlayer().getWebSocketSession()));
-    }
+        /**
+         * Send a message to all characters in a Zone.
+         *
+         * @param wsContext The WebSocketContext of the sender.
+         * @param message   The message to send.
+         * @param except    Don't send to these characters.
+         */
+        public void sendToZone(WebSocketContext wsContext, Long zoneId, Output message, MudCharacter... except) {
+                String zoneIdString = zoneId.toString();
+                List<MudCharacter> skip = List.of(except);
 
-    public void executeCommandAs(WebSocketContext originalContext, MudCharacter target, String command) {
-        if (target.getPlayer() == null)
-            return;
+                characterRepository.findByLocationRoomIdBetween(zoneId * 100, zoneId * 100 + 100)
+                                .stream()
+                                .filter(ch -> ch.getPlayer() != null)
+                                .filter(ch -> !wsContext.getSessionId().equals(ch.getPlayer().getWebSocketSession()))
+                                .filter(ch -> !skip.contains(ch))
+                                .filter(ch -> zoneIdString
+                                                .equals(ch.getLocation().getRoom().getId().toString().substring(0,
+                                                                zoneIdString.length())))
+                                .forEach(ch -> sendTo(ch, message));
+        }
 
-        Map<String, Object> attributes = sessionAttributeService
-                .getSessionAttributes(target.getPlayer().getWebSocketSession());
+        /**
+         * Send a message to all characters in a Room.
+         *
+         * @param roomId  The ID of the room to send to.
+         * @param message The message to send.
+         * @param except  Don't send to these characters.
+         */
+        public void sendToRoom(Long roomId, Output message, MudCharacter... except) {
+                List<MudCharacter> skip = List.of(except);
+                characterRepository.findByLocationRoomId(roomId)
+                                .stream()
+                                .filter(ch -> ch.getPlayer() != null)
+                                .filter(ch -> !skip.contains(ch))
+                                .forEach(ch -> sendTo(ch, message));
+        }
 
-        WebSocketContext targContext = WebSocketContext.build(new StompPrincipal(target.getPlayer().getUsername()),
-                target.getPlayer().getWebSocketSession(), attributes);
+        /**
+         * Send a message to the provided list of characters.
+         *
+         * @param targets The characters to send to.
+         * @param message The message to send.
+         */
+        public void sendToTargets(List<MudCharacter> targets, Output message) {
+                targets
+                                .forEach(ch -> sendTo(ch, message));
+        }
 
-        simpMessagingTemplate.convertAndSendToUser(targContext.getPrincipal().getName(), "/queue/input",
-                new Input(command), buildMessageHeaders(target.getPlayer().getWebSocketSession()));
-    }
+        /**
+         * Send a message to the provided list of characters.
+         *
+         * @param ch      The character to send to.
+         * @param message The message to send.
+         */
+        public void sendTo(MudCharacter ch, Output message) {
+                if (ch.getPlayer() == null) {
+                        return;
+                }
+
+                Map<String, Object> attributes = sessionAttributeService
+                                .getSessionAttributes(ch.getPlayer().getWebSocketSession());
+
+                if (!"commandQuestion".equals(attributes.get("MUD.QUESTION"))) {
+                        return;
+                }
+
+                WebSocketContext targetWsContext = WebSocketContext.build(
+                                new StompPrincipal(ch.getPlayer().getUsername()),
+                                ch.getPlayer().getWebSocketSession(),
+                                attributes);
+
+                Output messageWithPrompt = appendPrompt(targetWsContext, message);
+                MessageHeaders messageHeaders = buildMessageHeaders(ch.getPlayer().getWebSocketSession());
+
+                simpMessagingTemplate.convertAndSendToUser(
+                                targetWsContext.getPrincipal().getName(),
+                                "/queue/output",
+                                messageWithPrompt,
+                                messageHeaders);
+        }
+
+        public void executeCommandAs(WebSocketContext originalContext, MudCharacter target, String command) {
+                if (target.getPlayer() == null) {
+                        return;
+                }
+
+                // 1) Retrieve the target's session attributes
+                Map<String, Object> attributes = sessionAttributeService
+                                .getSessionAttributes(target.getPlayer().getWebSocketSession());
+
+                // 2) Rebuild a WebSocketContext for the target
+                WebSocketContext targetWsContext = WebSocketContext.build(
+                                new StompPrincipal(target.getPlayer().getUsername()),
+                                target.getPlayer().getWebSocketSession(),
+                                attributes);
+
+                // 3) Set thread-local context so Questions see the right session
+                webSocketContextAware.setWebSocketContext(targetWsContext);
+
+                // 4) Process the forced input via your shared pipeline
+                Input input = new Input(command);
+                Output output = inputProcessingService.processInput(targetWsContext, input);
+
+                // 5) Send the resulting Output back to the target on /queue/output
+                MessageHeaders headers = buildMessageHeaders(target.getPlayer().getWebSocketSession());
+                simpMessagingTemplate.convertAndSendToUser(
+                                target.getPlayer().getUsername(),
+                                "/queue/output",
+                                output,
+                                headers);
+        }
 }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/service/InputProcessingService.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/service/InputProcessingService.java
@@ -1,0 +1,38 @@
+package com.agonyforge.mud.demo.service;
+
+import com.agonyforge.mud.core.cli.Question;
+import com.agonyforge.mud.core.cli.Response;
+import com.agonyforge.mud.core.web.model.Input;
+import com.agonyforge.mud.core.web.model.Output;
+import com.agonyforge.mud.core.web.model.WebSocketContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Service;
+
+import static com.agonyforge.mud.core.config.SessionConfiguration.MUD_QUESTION;
+
+@Service
+public class InputProcessingService {
+    private final ApplicationContext applicationContext;
+
+    @Autowired
+    public InputProcessingService(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    public Output processInput(WebSocketContext wsContext, Input input) {
+        String questionName = (String) wsContext.getAttributes().get(MUD_QUESTION);
+        Question currentQuestion = applicationContext.getBean(questionName, Question.class);
+
+        Response response = currentQuestion.answer(wsContext, input);
+        Question nextQuestion = response.getNext();
+
+        Output output = new Output();
+        response.getFeedback().ifPresent(output::append);
+        output.append(nextQuestion.prompt(wsContext));
+
+        wsContext.getAttributes().put(MUD_QUESTION, nextQuestion.getBeanName());
+
+        return output;
+    }
+}

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/ForceCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/ForceCommandTest.java
@@ -1,23 +1,35 @@
 package com.agonyforge.mud.demo.cli.command;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationContext;
 
 import com.agonyforge.mud.core.cli.Question;
+import static com.agonyforge.mud.core.config.SessionConfiguration.MUD_CHARACTER;
 import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.impl.CharacterComponent;
+import com.agonyforge.mud.demo.model.impl.LocationComponent;
 import com.agonyforge.mud.demo.model.impl.MudCharacter;
+import com.agonyforge.mud.demo.model.impl.MudRoom;
 import com.agonyforge.mud.demo.model.repository.MudCharacterRepository;
 import com.agonyforge.mud.demo.service.CommService;
 
@@ -25,24 +37,24 @@ import com.agonyforge.mud.demo.service.CommService;
 class ForceCommandTest {
     @Mock
     private RepositoryBundle repositoryBundle;
-
-    @Mock
-    private MudCharacterRepository characterRepository;
-
     @Mock
     private CommService commService;
-
     @Mock
     private ApplicationContext applicationContext;
-
     @Mock
     private WebSocketContext webSocketContext;
-
     @Mock
     private Question question;
-
     @Mock
-    private MudCharacter executor;
+    private MudCharacter executor, target;
+    @Mock
+    private CharacterComponent executorComponent, targetComponent;
+    @Mock
+    private LocationComponent locationComponent;
+    @Mock
+    private MudRoom room;
+    @Mock
+    private Command dummyCommand;
 
     private ForceCommand uut;
     private final Random random = new Random();
@@ -54,36 +66,98 @@ class ForceCommandTest {
 
     @Test
     void testForceMissingTarget() {
-        List<String> tokens = List.of("FORCE");
         Output output = new Output();
+        Question result = uut.execute(question, webSocketContext, List.of("FORCE"), new Input("force"), output);
 
-        Question result = uut.execute(question, webSocketContext, tokens, new Input("force"), output);
-
-        assertEquals(question, result);
+        assertSame(question, result);
         assertEquals("[default]Who would you like to force?", output.toString().trim());
     }
 
     @Test
     void testForceMissingCommand() {
-        List<String> tokens = List.of("FORCE", "Bob");
         Output output = new Output();
+        Question result = uut.execute(question, webSocketContext, List.of("FORCE", "Bob"), new Input("force Bob"),
+                output);
 
-        Question result = uut.execute(question, webSocketContext, tokens, new Input("force Bob"), output);
-
-        assertEquals(question, result);
+        assertSame(question, result);
         assertEquals("[default]What would you like to force them to do?", output.toString().trim());
     }
 
     @Test
-    void testCommandDoesNotExist() {
-        List<String> tokens = List.of("FORCE", "Bob", "dance");
+    void testTargetNotFound() {
         Output output = new Output();
+        MudCharacterRepository repo = mock(MudCharacterRepository.class);
+        when(repositoryBundle.getCharacterRepository()).thenReturn(repo);
 
-        when(applicationContext.containsBean("danceCommand")).thenReturn(false);
+        long execId = random.nextLong();
+        when(webSocketContext.getAttributes()).thenReturn(Map.of(MUD_CHARACTER, execId));
+        when(repo.findById(execId)).thenReturn(Optional.of(executor));
 
-        Question result = uut.execute(question, webSocketContext, tokens, new Input("force Bob dance"), output);
+        when(executor.getLocation()).thenReturn(locationComponent); // Needed for not being in void
+        when(locationComponent.getRoom()).thenReturn(room);
 
-        assertEquals(question, result);
-        assertEquals("[default]That command does not exist: dance", output.toString().trim());
+        Question result = uut.execute(
+                question, webSocketContext,
+                List.of("FORCE", "Bob", "say", "Hello"),
+                new Input("force Bob say Hello"), output);
+
+        assertSame(question, result);
+        assertEquals("[default]There isn't anyone by that name.", output.toString().trim());
+    }
+
+    @Test
+    void testForceSuccess() {
+        // --- arrange ---
+        MudCharacterRepository repo = mock(MudCharacterRepository.class);
+        when(repositoryBundle.getCharacterRepository()).thenReturn(repo);
+
+        // executor in room
+        long execId = random.nextLong();
+        when(webSocketContext.getAttributes()).thenReturn(Map.of(MUD_CHARACTER, execId));
+        when(repo.findById(execId)).thenReturn(Optional.of(executor));
+        when(executor.getLocation()).thenReturn(locationComponent);
+        when(locationComponent.getRoom()).thenReturn(room);
+
+        // room contains executor + target
+        when(repo.findByLocationRoom(room)).thenReturn(List.of(executor, target));
+
+        // names
+        when(executor.getCharacter()).thenReturn(executorComponent);
+        when(executorComponent.getName()).thenReturn("Executor");
+        when(target.getCharacter()).thenReturn(targetComponent);
+        when(targetComponent.getName()).thenReturn("Bob");
+        // when(target.getLocation()).thenReturn(locationComponent);
+
+        // SAY command bean exists
+        // when(applicationContext.containsBean("sayCommand")).thenReturn(true);
+        // when(applicationContext.getBean("sayCommand")).thenReturn(dummyCommand);
+
+        // --- act ---
+        Output out = new Output();
+        Question res = uut.execute(question, webSocketContext,
+                List.of("FORCE", "Bob", "say", "Hello"), new Input("force Bob say Hello"), out);
+
+        // --- assert ---
+        assertSame(question, res);
+        assertEquals(
+                "[yellow]You forced Bob to 'say Hello[yellow]'!",
+                out.toString().trim());
+        verify(commService).sendTo(eq(target), any(Output.class));
+        verify(commService).executeCommandAs(webSocketContext, target, "say Hello");
+    }
+
+    @Test
+    void testForceCommandWithNestedForce() {
+        Output output = new Output();
+        Question result = uut.execute(
+                question, webSocketContext,
+                List.of("FORCE", "Bob", "force", "Bob", "say", "Hello"),
+                new Input("force Bob force Bob say Hello"), output);
+
+        assertSame(question, result);
+        assertEquals(
+                "[default]You cannot force someone to force others!",
+                output.toString().trim());
+        verifyNoInteractions(repositoryBundle, applicationContext, commService);
     }
 }

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/ForceCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/ForceCommandTest.java
@@ -1,0 +1,89 @@
+package com.agonyforge.mud.demo.cli.command;
+
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+
+import com.agonyforge.mud.core.cli.Question;
+import com.agonyforge.mud.core.web.model.Input;
+import com.agonyforge.mud.core.web.model.Output;
+import com.agonyforge.mud.core.web.model.WebSocketContext;
+import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.impl.MudCharacter;
+import com.agonyforge.mud.demo.model.repository.MudCharacterRepository;
+import com.agonyforge.mud.demo.service.CommService;
+
+@ExtendWith(MockitoExtension.class)
+class ForceCommandTest {
+    @Mock
+    private RepositoryBundle repositoryBundle;
+
+    @Mock
+    private MudCharacterRepository characterRepository;
+
+    @Mock
+    private CommService commService;
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    @Mock
+    private WebSocketContext webSocketContext;
+
+    @Mock
+    private Question question;
+
+    @Mock
+    private MudCharacter executor;
+
+    private ForceCommand uut;
+    private final Random random = new Random();
+
+    @BeforeEach
+    void setUp() {
+        uut = new ForceCommand(repositoryBundle, commService, applicationContext);
+    }
+
+    @Test
+    void testForceMissingTarget() {
+        List<String> tokens = List.of("FORCE");
+        Output output = new Output();
+
+        Question result = uut.execute(question, webSocketContext, tokens, new Input("force"), output);
+
+        assertEquals(question, result);
+        assertEquals("[default]Who would you like to force?", output.toString().trim());
+    }
+
+    @Test
+    void testForceMissingCommand() {
+        List<String> tokens = List.of("FORCE", "Bob");
+        Output output = new Output();
+
+        Question result = uut.execute(question, webSocketContext, tokens, new Input("force Bob"), output);
+
+        assertEquals(question, result);
+        assertEquals("[default]What would you like to force them to do?", output.toString().trim());
+    }
+
+    @Test
+    void testCommandDoesNotExist() {
+        List<String> tokens = List.of("FORCE", "Bob", "dance");
+        Output output = new Output();
+
+        when(applicationContext.containsBean("danceCommand")).thenReturn(false);
+
+        Question result = uut.execute(question, webSocketContext, tokens, new Input("force Bob dance"), output);
+
+        assertEquals(question, result);
+        assertEquals("[default]That command does not exist: dance", output.toString().trim());
+    }
+}

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/service/CommServiceTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/service/CommServiceTest.java
@@ -96,7 +96,8 @@ public class CommServiceTest {
         lenient().when(webSocketContext.getSessionId()).thenReturn(wsSessionId);
 
         lenient().when(characterRepository.findByLocationRoomId(eq(100L))).thenReturn(List.of(ch, target));
-        lenient().when(characterRepository.findByLocationRoomIdBetween(eq(100L), eq(200L))).thenReturn(List.of(ch, target));
+        lenient().when(characterRepository.findByLocationRoomIdBetween(eq(100L), eq(200L)))
+                .thenReturn(List.of(ch, target));
         lenient().when(characterRepository.findAll()).thenReturn(List.of(ch, target, other));
 
         lenient().when(ch.getPlayer()).thenReturn(chPlayer);
@@ -135,29 +136,27 @@ public class CommServiceTest {
     @Test
     void testSendToAllWebsocket() {
         CommService uut = new CommService(
-            applicationContext,
-            simpMessagingTemplate,
-            simpUserRegistry,
-            sessionAttributeService,
-            characterRepository);
+                applicationContext,
+                simpMessagingTemplate,
+                simpUserRegistry,
+                sessionAttributeService,
+                null, characterRepository, null);
 
         Output message = new Output("message");
 
         uut.sendToAll(webSocketContext, message);
 
         verify(simpMessagingTemplate).convertAndSendToUser(
-            eq(targetPrincipal),
-            eq("/queue/output"),
-            any(Output.class),
-            any(MessageHeaders.class)
-        );
+                eq(targetPrincipal),
+                eq("/queue/output"),
+                any(Output.class),
+                any(MessageHeaders.class));
 
         verify(simpMessagingTemplate).convertAndSendToUser(
-            eq(otherPrincipal),
-            eq("/queue/output"),
-            any(Output.class),
-            any(MessageHeaders.class)
-        );
+                eq(otherPrincipal),
+                eq("/queue/output"),
+                any(Output.class),
+                any(MessageHeaders.class));
 
         verifyNoMoreInteractions(simpMessagingTemplate);
     }
@@ -165,36 +164,33 @@ public class CommServiceTest {
     @Test
     void testSendToAll() {
         CommService uut = new CommService(
-            applicationContext,
-            simpMessagingTemplate,
-            simpUserRegistry,
-            sessionAttributeService,
-            characterRepository);
+                applicationContext,
+                simpMessagingTemplate,
+                simpUserRegistry,
+                sessionAttributeService,
+                null, characterRepository, null);
 
         Output message = new Output("message");
 
         uut.sendToAll(message);
 
         verify(simpMessagingTemplate).convertAndSendToUser(
-            eq(principal),
-            eq("/queue/output"),
-            any(Output.class),
-            any(MessageHeaders.class)
-        );
+                eq(principal),
+                eq("/queue/output"),
+                any(Output.class),
+                any(MessageHeaders.class));
 
         verify(simpMessagingTemplate).convertAndSendToUser(
-            eq(targetPrincipal),
-            eq("/queue/output"),
-            any(Output.class),
-            any(MessageHeaders.class)
-        );
+                eq(targetPrincipal),
+                eq("/queue/output"),
+                any(Output.class),
+                any(MessageHeaders.class));
 
         verify(simpMessagingTemplate).convertAndSendToUser(
-            eq(otherPrincipal),
-            eq("/queue/output"),
-            any(Output.class),
-            any(MessageHeaders.class)
-        );
+                eq(otherPrincipal),
+                eq("/queue/output"),
+                any(Output.class),
+                any(MessageHeaders.class));
 
         verifyNoMoreInteractions(simpMessagingTemplate);
     }
@@ -202,36 +198,33 @@ public class CommServiceTest {
     @Test
     void testSendToAllWithoutFlags() {
         CommService uut = new CommService(
-            applicationContext,
-            simpMessagingTemplate,
-            simpUserRegistry,
-            sessionAttributeService,
-            characterRepository);
+                applicationContext,
+                simpMessagingTemplate,
+                simpUserRegistry,
+                sessionAttributeService,
+                null, characterRepository, null);
 
         Output message = new Output("message");
 
         uut.sendToAllWithoutFlags(message, EnumSet.of(RoomFlag.INDOORS));
 
         verify(simpMessagingTemplate, never()).convertAndSendToUser(
-            eq(principal),
-            eq("/queue/output"),
-            any(Output.class),
-            any(MessageHeaders.class)
-        );
+                eq(principal),
+                eq("/queue/output"),
+                any(Output.class),
+                any(MessageHeaders.class));
 
         verify(simpMessagingTemplate, never()).convertAndSendToUser(
-            eq(targetPrincipal),
-            eq("/queue/output"),
-            any(Output.class),
-            any(MessageHeaders.class)
-        );
+                eq(targetPrincipal),
+                eq("/queue/output"),
+                any(Output.class),
+                any(MessageHeaders.class));
 
         verify(simpMessagingTemplate).convertAndSendToUser(
-            eq(otherPrincipal),
-            eq("/queue/output"),
-            any(Output.class),
-            any(MessageHeaders.class)
-        );
+                eq(otherPrincipal),
+                eq("/queue/output"),
+                any(Output.class),
+                any(MessageHeaders.class));
 
         verifyNoMoreInteractions(simpMessagingTemplate);
     }
@@ -239,22 +232,21 @@ public class CommServiceTest {
     @Test
     void testSendToZone() {
         CommService uut = new CommService(
-            applicationContext,
-            simpMessagingTemplate,
-            simpUserRegistry,
-            sessionAttributeService,
-            characterRepository);
+                applicationContext,
+                simpMessagingTemplate,
+                simpUserRegistry,
+                sessionAttributeService,
+                null, characterRepository, null);
 
         Output message = new Output("message");
 
-        uut.sendToZone(webSocketContext,1L, message);
+        uut.sendToZone(webSocketContext, 1L, message);
 
         verify(simpMessagingTemplate).convertAndSendToUser(
-            eq(targetPrincipal),
-            eq("/queue/output"),
-            any(Output.class),
-            any(MessageHeaders.class)
-        );
+                eq(targetPrincipal),
+                eq("/queue/output"),
+                any(Output.class),
+                any(MessageHeaders.class));
 
         verifyNoMoreInteractions(simpMessagingTemplate);
     }
@@ -262,29 +254,27 @@ public class CommServiceTest {
     @Test
     void testSendToRoom() {
         CommService uut = new CommService(
-            applicationContext,
-            simpMessagingTemplate,
-            simpUserRegistry,
-            sessionAttributeService,
-            characterRepository);
+                applicationContext,
+                simpMessagingTemplate,
+                simpUserRegistry,
+                sessionAttributeService,
+                null, characterRepository, null);
 
         Output message = new Output("message");
 
         uut.sendToRoom(100L, message);
 
         verify(simpMessagingTemplate).convertAndSendToUser(
-            eq(targetPrincipal),
-            eq("/queue/output"),
-            any(Output.class),
-            any(MessageHeaders.class)
-        );
+                eq(targetPrincipal),
+                eq("/queue/output"),
+                any(Output.class),
+                any(MessageHeaders.class));
 
         verify(simpMessagingTemplate).convertAndSendToUser(
-            eq(principal),
-            eq("/queue/output"),
-            any(Output.class),
-            any(MessageHeaders.class)
-        );
+                eq(principal),
+                eq("/queue/output"),
+                any(Output.class),
+                any(MessageHeaders.class));
 
         verifyNoMoreInteractions(simpMessagingTemplate);
     }
@@ -292,29 +282,27 @@ public class CommServiceTest {
     @Test
     void testSendToTargets() {
         CommService uut = new CommService(
-            applicationContext,
-            simpMessagingTemplate,
-            simpUserRegistry,
-            sessionAttributeService,
-            characterRepository);
+                applicationContext,
+                simpMessagingTemplate,
+                simpUserRegistry,
+                sessionAttributeService,
+                null, characterRepository, null);
 
         Output message = new Output("message");
 
         uut.sendToTargets(List.of(ch, target), message);
 
         verify(simpMessagingTemplate).convertAndSendToUser(
-            eq(principal),
-            eq("/queue/output"),
-            any(Output.class),
-            any(MessageHeaders.class)
-        );
+                eq(principal),
+                eq("/queue/output"),
+                any(Output.class),
+                any(MessageHeaders.class));
 
         verify(simpMessagingTemplate).convertAndSendToUser(
-            eq(targetPrincipal),
-            eq("/queue/output"),
-            any(Output.class),
-            any(MessageHeaders.class)
-        );
+                eq(targetPrincipal),
+                eq("/queue/output"),
+                any(Output.class),
+                any(MessageHeaders.class));
 
         verifyNoMoreInteractions(simpMessagingTemplate);
     }
@@ -322,22 +310,21 @@ public class CommServiceTest {
     @Test
     void testSendTo() {
         CommService uut = new CommService(
-            applicationContext,
-            simpMessagingTemplate,
-            simpUserRegistry,
-            sessionAttributeService,
-            characterRepository);
+                applicationContext,
+                simpMessagingTemplate,
+                simpUserRegistry,
+                sessionAttributeService,
+                null, characterRepository, null);
 
         Output message = new Output("message");
 
         uut.sendTo(ch, message);
 
         verify(simpMessagingTemplate).convertAndSendToUser(
-            eq(principal),
-            eq("/queue/output"),
-            outputCaptor.capture(),
-            any(MessageHeaders.class)
-        );
+                eq(principal),
+                eq("/queue/output"),
+                outputCaptor.capture(),
+                any(MessageHeaders.class));
 
         verifyNoMoreInteractions(simpMessagingTemplate);
 


### PR DESCRIPTION
Summary
Introduced the force command that allows one character to make another character execute a command. Added strong validation and reused existing infrastructure to ensure consistency and reliability.

Features
✅ Added force command implementation

✅ Created and integrated new InputProcessingService:

Used to validate command existence and arguments (dry-run)

Reuses command pipeline without duplicating logic

✅ Ensures feedback is shown to both the issuer and the target

✅ Prevents execution of non-existent commands or improperly formatted ones

Technical Details
Commands are resolved and executed using the same logic as normal input, with WebSocketContext swapped for the target

Fallbacks and error messages are gracefully handled using existing Output structures
