### PR TITLE
Fight enhancements

### DIFF
--- a/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/web/model/Output.java
+++ b/agonyforge-mud-core/src/main/java/com/agonyforge/mud/core/web/model/Output.java
@@ -56,6 +56,10 @@ public class Output {
         return new ArrayList<>(lines);
     }
 
+    public boolean isEmpty() {
+        return lines.isEmpty();
+    }
+
     @Override
     public String toString() {
         return String.join("\n", lines);

--- a/agonyforge-mud-demo/src/main/docker/Dockerfile.codebuild
+++ b/agonyforge-mud-demo/src/main/docker/Dockerfile.codebuild
@@ -1,12 +1,12 @@
 # sqlite4java crashes in the alpine image so we build this JAR in Amazon Linux instead
-FROM amazoncorretto:17-al2-jdk as build
+FROM public.ecr.aws/docker/library/amazoncorretto:17-al2-jdk as build
 LABEL maintainer="scion@agonyforge.com"
 WORKDIR /opt/build
 COPY . /opt/build
 RUN cd /opt/build \
     && ./gradlew --console=plain clean build -x docker --info --stacktrace
 
-FROM amazoncorretto:17-alpine-jdk
+FROM public.ecr.aws/docker/library/amazoncorretto:17-alpine-jdk
 LABEL maintainer="scion@agonyforge.com"
 EXPOSE 8080
 COPY --from=build /opt/build/agonyforge-mud-demo/build/libs/agonyforge-mud-demo-*.jar /opt/mud/mud.jar

--- a/agonyforge-mud-demo/src/main/docker/Dockerfile.local
+++ b/agonyforge-mud-demo/src/main/docker/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17-alpine-jdk
+FROM public.ecr.aws/docker/library/amazoncorretto:17-alpine-jdk
 LABEL maintainer="scion@agonyforge.com"
 EXPOSE 8080
 COPY agonyforge-mud-demo-*.jar /opt/app/mud.jar

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/DropCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/DropCommand.java
@@ -54,7 +54,10 @@ public class DropCommand extends AbstractCommand {
 
         output.append("[default]You drop %s[default].", target.getItem().getShortDescription());
         getCommService().sendToRoom(ch.getLocation().getRoom().getId(),
-            new Output("[default]%s drops %s[default].", ch.getCharacter().getName(), target.getItem().getShortDescription()));
+            new Output("[default]%s drops %s[default].",
+                ch.getCharacter().getName(),
+                target.getItem().getShortDescription()),
+            ch);
 
         return question;
     }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/HitCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/HitCommand.java
@@ -7,6 +7,7 @@ import com.agonyforge.mud.core.web.model.Input;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.core.web.model.WebSocketContext;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
+import com.agonyforge.mud.demo.model.constant.AdminFlag;
 import com.agonyforge.mud.demo.model.constant.Effort;
 import com.agonyforge.mud.demo.model.constant.WearSlot;
 import com.agonyforge.mud.demo.model.impl.Fight;
@@ -35,6 +36,12 @@ public class HitCommand extends AbstractCommand {
                                FightRepository fightRepository,
                                Output chOutput, Output targetOutput, Output roomOutput,
                                MudCharacter ch, MudCharacter target) {
+
+        if (target.getPlayer() != null && target.getPlayer().getAdminFlags().contains(AdminFlag.PEACEFUL)) {
+            chOutput.append("[white]Somehow you just don't feel like doing that.");
+            return;
+        }
+
         // Attempt roll
         final int attemptTarget = 12 + target.getCharacter().getDefense();
 
@@ -151,8 +158,13 @@ public class HitCommand extends AbstractCommand {
 
         doHit(getRepositoryBundle(), diceService, fightRepository, output, targetOutput, roomOutput, ch, target);
 
-        getCommService().sendTo(target, targetOutput);
-        getCommService().sendToRoom(ch.getLocation().getRoom().getId(), roomOutput, ch, target);
+        if (!targetOutput.isEmpty()) {
+            getCommService().sendTo(target, targetOutput);
+        }
+
+        if (!roomOutput.isEmpty()) {
+            getCommService().sendToRoom(ch.getLocation().getRoom().getId(), roomOutput, ch, target);
+        }
 
         return question;
     }

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/HitCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/HitCommand.java
@@ -153,6 +153,12 @@ public class HitCommand extends AbstractCommand {
         }
 
         MudCharacter target = targetOptional.get();
+
+        if (fightRepository.findByAttackerAndDefender(ch, target).isPresent() || fightRepository.findByAttackerAndDefender(target, ch).isPresent()) {
+            output.append("[red]You are already fighting %s!", target.getCharacter().getName());
+            return question;
+        }
+
         Output targetOutput = new Output();
         Output roomOutput = new Output();
 

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/HitCommand.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/command/HitCommand.java
@@ -36,8 +36,7 @@ public class HitCommand extends AbstractCommand {
                                Output chOutput, Output targetOutput, Output roomOutput,
                                MudCharacter ch, MudCharacter target) {
         // Attempt roll
-        DiceResult defense = diceService.roll(1, 20, target.getCharacter().getDefense());
-        final int attemptTarget = defense.getModifiedRoll(0);
+        final int attemptTarget = 12 + target.getCharacter().getDefense();
 
         DiceResult attempt = diceService.roll(1, 20);
         LOGGER.trace("Attempt result: {}", attempt);

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/CommandQuestion.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/cli/question/ingame/CommandQuestion.java
@@ -10,7 +10,6 @@ import com.agonyforge.mud.demo.cli.RepositoryBundle;
 import com.agonyforge.mud.demo.cli.command.Command;
 import com.agonyforge.mud.demo.cli.question.BaseQuestion;
 import com.agonyforge.mud.demo.cli.question.CommandException;
-import com.agonyforge.mud.demo.cli.question.login.CharacterSheetFormatter;
 import com.agonyforge.mud.demo.model.impl.CommandReference;
 import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import com.agonyforge.mud.demo.model.impl.Role;
@@ -49,9 +48,10 @@ public class CommandQuestion extends BaseQuestion {
         if (chOptional.isPresent()) {
             output
                 .append("")
-                .append("[green]%s [red]%s[default]> ",
+                .append("[green]%s [red]%d[dred]/[red]%d[default]> ",
                     chOptional.get().getCharacter().getName(),
-                    CharacterSheetFormatter.hearts(chOptional.get()));
+                    chOptional.get().getCharacter().getHitPoints(),
+                    chOptional.get().getCharacter().getMaxHitPoints());
         } else {
             output
                 .append("")

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/constant/AdminFlag.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/constant/AdminFlag.java
@@ -4,7 +4,8 @@ import com.agonyforge.mud.demo.model.util.BaseEnumSetConverter;
 import com.agonyforge.mud.demo.model.util.PersistentEnum;
 
 public enum AdminFlag implements PersistentEnum {
-    HOLYLIGHT("can see everything");
+    HOLYLIGHT("can see everything"),
+    PEACEFUL("cannot be attacked");
 
     private final String description;
 

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacterTemplate.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/model/impl/MudCharacterTemplate.java
@@ -42,6 +42,9 @@ public class MudCharacterTemplate extends AbstractMudObject {
         Arrays.stream(Effort.values())
             .forEach(effort -> instance.getCharacter().setBaseEffort(effort, getCharacter().getBaseEffort(effort)));
 
+        instance.getCharacter().setMaxHitPoints(getCharacter().getMaxHitPoints());
+        instance.getCharacter().setHitPoints(getCharacter().getHitPoints());
+
         return instance;
     }
 

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/service/FightService.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/service/FightService.java
@@ -71,16 +71,18 @@ public class FightService {
                         attacker.getCharacter().getName(),
                         defender.getCharacter().getName());
 
-                // attacker attacks
+                // the fight was initiated when the attacker attacked the defender
+                // if the defender was killed, no Fight should have been created
+                // that means it's time for the defender to retaliate
                 HitCommand.doHit(repositoryBundle, diceService, fightRepository,
+                    targetOutput, chOutput, roomOutput,
+                    defender, attacker);
+
+                // if the attacker is still alive, they can attack again
+                if (attacker.getCharacter().getHitPoints() > 0) {
+                    HitCommand.doHit(repositoryBundle, diceService, fightRepository,
                         chOutput, targetOutput, roomOutput,
                         attacker, defender);
-
-                // if they survived, defender attacks
-                if (defender.getCharacter().getHitPoints() > 0) {
-                    HitCommand.doHit(repositoryBundle, diceService, fightRepository,
-                        targetOutput, chOutput, roomOutput,
-                        defender, attacker);
                 }
 
                 // send all output

--- a/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/service/FightService.java
+++ b/agonyforge-mud-demo/src/main/java/com/agonyforge/mud/demo/service/FightService.java
@@ -5,6 +5,7 @@ import com.agonyforge.mud.core.service.timer.TimerEvent;
 import com.agonyforge.mud.core.web.model.Output;
 import com.agonyforge.mud.demo.cli.RepositoryBundle;
 import com.agonyforge.mud.demo.cli.command.HitCommand;
+import com.agonyforge.mud.demo.model.constant.AdminFlag;
 import com.agonyforge.mud.demo.model.impl.Fight;
 import com.agonyforge.mud.demo.model.impl.MudCharacter;
 import com.agonyforge.mud.demo.model.impl.MudRoom;
@@ -60,6 +61,21 @@ public class FightService {
             } else if (attacker.getLocation().getRoom() != defender.getLocation().getRoom()) {
                 LOGGER.warn("Attacker and defender in different rooms");
                 ended.add(fight);
+            } else if ((attacker.getPlayer() != null && attacker.getPlayer().getAdminFlags().contains(AdminFlag.PEACEFUL))
+                    || (defender.getPlayer() != null && defender.getPlayer().getAdminFlags().contains(AdminFlag.PEACEFUL))) {
+
+                ended.add(fight);
+
+                MudRoom room = attacker.getLocation().getRoom();
+
+                commService.sendTo(attacker, new Output("[white]You grow weary of fighting..."));
+                commService.sendTo(defender, new Output("[white]You grow weary of fighting..."));
+                commService.sendToRoom(
+                    room.getId(),
+                    new Output("[white]%s and %s suddenly stop fighting.",
+                        attacker.getCharacter().getName(),
+                        defender.getCharacter().getName()),
+                    attacker, defender);
             } else {
                 MudRoom room = attacker.getLocation().getRoom();
                 Output chOutput = new Output();
@@ -100,7 +116,9 @@ public class FightService {
                     commService.sendTo(defender, new Output("[white]You are bathed in a white light from above..."));
                     commService.sendToRoom(
                         room.getId(),
-                        new Output("[white]%s and %s are bathed in a white light from above...", attacker, defender),
+                        new Output("[white]%s and %s are bathed in a white light from above...",
+                            attacker.getCharacter().getName(),
+                            defender.getCharacter().getName()),
                         attacker, defender);
 
                     attacker.getCharacter().setHitPoints(attacker.getCharacter().getMaxHitPoints());

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/DropCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/DropCommandTest.java
@@ -182,7 +182,7 @@ public class DropCommandTest {
         verify(locationComponent).setWorn(eq(EnumSet.noneOf(WearSlot.class)));
         verify(itemRepository).save(eq(item));
         verify(itemRepository, never()).save(eq(other));
-        verify(commService).sendToRoom(eq(100L), any(Output.class));
+        verify(commService).sendToRoom(eq(100L), any(Output.class), eq(ch));
 
         assertEquals(question, result);
         assertTrue(output.getOutput().get(0).contains("You drop " + itemName));

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/HitCommandTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/command/HitCommandTest.java
@@ -139,7 +139,6 @@ public class HitCommandTest {
         when(room.getId()).thenReturn(roomId);
         when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
         when(characterRepository.findByLocationRoom(eq(room))).thenReturn(List.of(ch, target));
-        when(diceService.roll(eq(1), eq(20), eq(0))).thenReturn(new DiceResult(20, 0, 12));
         when(diceService.roll(eq(1), eq(20))).thenReturn(new DiceResult(20, 0, 11));
 
         Output output = new Output();
@@ -172,7 +171,6 @@ public class HitCommandTest {
         when(room.getId()).thenReturn(roomId);
         when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
         when(characterRepository.findByLocationRoom(eq(room))).thenReturn(List.of(ch, target));
-        when(diceService.roll(eq(1), eq(20), eq(0))).thenReturn(new DiceResult(20, 0, 12));
         when(diceService.roll(eq(1), eq(20))).thenReturn(new DiceResult(20, 0, 12));
         when(diceService.roll(eq(1), eq(4))).thenReturn(new DiceResult(4, 0, 4));
 
@@ -209,7 +207,6 @@ public class HitCommandTest {
         when(room.getId()).thenReturn(roomId);
         when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
         when(characterRepository.findByLocationRoom(eq(room))).thenReturn(List.of(ch, target));
-        when(diceService.roll(eq(1), eq(20), eq(0))).thenReturn(new DiceResult(20, 0, 12));
         when(diceService.roll(eq(1), eq(20))).thenReturn(new DiceResult(20, 0, 12));
         when(diceService.roll(eq(1), eq(6))).thenReturn(new DiceResult(6, 0, 4));
 
@@ -249,7 +246,6 @@ public class HitCommandTest {
         when(room.getId()).thenReturn(roomId);
         when(characterRepository.findById(eq(chId))).thenReturn(Optional.of(ch));
         when(characterRepository.findByLocationRoom(eq(room))).thenReturn(List.of(ch, target));
-        when(diceService.roll(eq(1), eq(20), eq(0))).thenReturn(new DiceResult(20, 0, 12));
         when(diceService.roll(eq(1), eq(20))).thenReturn(new DiceResult(20, 0, 20));
         when(diceService.roll(eq(1), eq(4))).thenReturn(new DiceResult(4, 0, 4));
         when(diceService.roll(eq(1), eq(12), anyInt())).thenReturn(new DiceResult(12, 0, 8));

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/ingame/CommandQuestionTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/cli/question/ingame/CommandQuestionTest.java
@@ -96,7 +96,7 @@ public class CommandQuestionTest {
 
         assertEquals(2, output.getOutput().size());
         assertEquals("", output.getOutput().get(0));
-        assertEquals("[green]null [red][default]> ", output.getOutput().get(1));
+        assertEquals("[green]null [red]0[dred]/[red]0[default]> ", output.getOutput().get(1));
     }
 
     @Test

--- a/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/service/FightServiceTest.java
+++ b/agonyforge-mud-demo/src/test/java/com/agonyforge/mud/demo/service/FightServiceTest.java
@@ -206,7 +206,7 @@ public class FightServiceTest {
                 any(FightRepository.class),
                 any(Output.class), any(Output.class), any(Output.class),
                 any(MudCharacter.class), any(MudCharacter.class)
-            ), times(2));
+            ), times(1));
 
             verify(commService, atLeast(1)).sendTo(eq(attacker), outputCaptor.capture());
             verify(commService, atLeast(1)).sendTo(eq(defender), outputCaptor.capture());


### PR DESCRIPTION
* DROP command did not exclude a message for the room from being sent to the character.
* Pull Docker images from AWS instead of Docker Hub to avoid 401s.
* CONFIG flag for PEACEFUL so that you cannot be attacked.
* Display HP in prompt instead of hearts.
* Reverse order of fight processing so attacker doesn't get a free second hit at the start.
* Prevent being able to spam HIT command to get extra hits in a fight.
* Defender doesn't roll to defend. Attacker's target is always 12+DEF. In the future this will also be modified by equipment and environmental factors.